### PR TITLE
Naming changes on ta4j 0.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 		<dependency>
 			<groupId>org.ta4j</groupId>
 			<artifactId>ta4j-core</artifactId>
-			<version>0.10</version>
+			<version>0.11</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.javax.persistence</groupId>

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/CandlestickHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/CandlestickHandler.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.json.JSONArray;
-import org.ta4j.core.BaseTick;
-import org.ta4j.core.Tick;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.Bar;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.Const;
@@ -44,7 +44,7 @@ public class CandlestickHandler implements ChannelCallbackHandler {
 			final BitfinexStreamSymbol channelSymbol, final JSONArray jsonArray) throws APIException {
 
 		// channel symbol trade:1m:tLTCUSD
-		final List<Tick> ticksBuffer = new ArrayList<>();
+		final List<Bar> ticksBuffer = new ArrayList<>();
 		
 		// Snapshots contain multiple Bars, Updates only one
 		if(jsonArray.get(0) instanceof JSONArray) {
@@ -65,7 +65,7 @@ public class CandlestickHandler implements ChannelCallbackHandler {
 	/**
 	 * Parse a candlestick from JSON result
 	 */
-	private void parseCandlestick(final List<Tick> ticksBuffer, final JSONArray parts) {
+	private void parseCandlestick(final List<Bar> ticksBuffer, final JSONArray parts) {
 		// 0 = Timestamp, 1 = Open, 2 = Close, 3 = High, 4 = Low,  5 = Volume
 		final Instant i = Instant.ofEpochMilli(parts.getLong(0));
 		final ZonedDateTime withTimezone = ZonedDateTime.ofInstant(i, Const.BITFINEX_TIMEZONE);
@@ -76,7 +76,7 @@ public class CandlestickHandler implements ChannelCallbackHandler {
 		final double low = parts.getDouble(4);
 		final double volume = parts.getDouble(5);
 		
-		final Tick tick = new BaseTick(withTimezone, open, high, low, close, volume);
+		final Bar tick = new BaseBar(withTimezone, open, high, low, close, volume);
 		ticksBuffer.add(tick);
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/TickHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/TickHandler.java
@@ -20,8 +20,8 @@ package com.github.jnidzwetzki.bitfinex.v2.callback.channel;
 import java.time.ZonedDateTime;
 
 import org.json.JSONArray;
-import org.ta4j.core.BaseTick;
-import org.ta4j.core.Tick;
+import org.ta4j.core.BaseBar;
+import org.ta4j.core.Bar;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.Const;
@@ -48,7 +48,7 @@ public class TickHandler implements ChannelCallbackHandler {
 		final double price = jsonArray.getDouble(6);
 		
 		// Volume is set to 0, because the ticker contains only the daily volume
-		final Tick tick = new BaseTick(ZonedDateTime.now(Const.BITFINEX_TIMEZONE), price, price, 
+		final Bar tick = new BaseBar(ZonedDateTime.now(Const.BITFINEX_TIMEZONE), price, price, 
 				price, price, 0);
 		
 		bitfinexApiBroker.getQuoteManager().handleNewTick(currencyPair, tick);

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
-import org.ta4j.core.Tick;
+import org.ta4j.core.Bar;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeCandlesCommand;
@@ -43,7 +43,7 @@ public class QuoteManager {
 	/**
 	 * The last ticks
 	 */
-	protected final Map<BitfinexStreamSymbol, Tick> lastTick;
+	protected final Map<BitfinexStreamSymbol, Bar> lastTick;
 	
 	/**
 	 * The last tick timestamp
@@ -53,12 +53,12 @@ public class QuoteManager {
 	/**
 	 * The BitfinexCurrencyPair callbacks
 	 */
-	private final BiConsumerCallbackManager<BitfinexTickerSymbol, Tick> tickerCallbacks;
+	private final BiConsumerCallbackManager<BitfinexTickerSymbol, Bar> tickerCallbacks;
 
 	/**
 	 * The Bitfinex Candlestick callbacks
 	 */
-	private final BiConsumerCallbackManager<BitfinexCandlestickSymbol, Tick> candleCallbacks;
+	private final BiConsumerCallbackManager<BitfinexCandlestickSymbol, Bar> candleCallbacks;
 	
 	/**
 	 * The channel callbacks
@@ -127,7 +127,7 @@ public class QuoteManager {
 	 * @param currencyPair
 	 * @return 
 	 */
-	public Tick getLastTick(final BitfinexTickerSymbol currencyPair) {
+	public Bar getLastTick(final BitfinexTickerSymbol currencyPair) {
 		synchronized (lastTick) {
 			return lastTick.get(currencyPair);
 		}
@@ -150,7 +150,7 @@ public class QuoteManager {
 	 * @throws APIException
 	 */
 	public void registerTickCallback(final BitfinexTickerSymbol symbol, 
-			final BiConsumer<BitfinexTickerSymbol, Tick> callback) throws APIException {
+			final BiConsumer<BitfinexTickerSymbol, Bar> callback) throws APIException {
 		
 		tickerCallbacks.registerCallback(symbol, callback);
 	}
@@ -163,7 +163,7 @@ public class QuoteManager {
 	 * @throws APIException
 	 */
 	public boolean removeTickCallback(final BitfinexTickerSymbol symbol, 
-			final BiConsumer<BitfinexTickerSymbol, Tick> callback) throws APIException {
+			final BiConsumer<BitfinexTickerSymbol, Bar> callback) throws APIException {
 		
 		return tickerCallbacks.removeCallback(symbol, callback);
 	}
@@ -173,7 +173,7 @@ public class QuoteManager {
 	 * @param symbol
 	 * @param ticksArray
 	 */
-	public void handleTicksList(final BitfinexTickerSymbol symbol, final List<Tick> ticksBuffer) {
+	public void handleTicksList(final BitfinexTickerSymbol symbol, final List<Bar> ticksBuffer) {
 		tickerCallbacks.handleEventsList(symbol, ticksBuffer);
 	}
 	
@@ -182,7 +182,7 @@ public class QuoteManager {
 	 * @param symbol
 	 * @param tick
 	 */
-	public void handleNewTick(final BitfinexTickerSymbol currencyPair, final Tick tick) {
+	public void handleNewTick(final BitfinexTickerSymbol currencyPair, final Bar tick) {
 		
 		synchronized (lastTick) {
 			lastTick.put(currencyPair, tick);
@@ -224,7 +224,7 @@ public class QuoteManager {
 	 * @throws APIException
 	 */
 	public void registerCandlestickCallback(final BitfinexCandlestickSymbol symbol, 
-			final BiConsumer<BitfinexCandlestickSymbol, Tick> callback) throws APIException {
+			final BiConsumer<BitfinexCandlestickSymbol, Bar> callback) throws APIException {
 		
 		candleCallbacks.registerCallback(symbol, callback);
 	}
@@ -237,7 +237,7 @@ public class QuoteManager {
 	 * @throws APIException
 	 */
 	public boolean removeCandlestickCallback(final BitfinexCandlestickSymbol symbol, 
-			final BiConsumer<BitfinexCandlestickSymbol, Tick> callback) throws APIException {
+			final BiConsumer<BitfinexCandlestickSymbol, Bar> callback) throws APIException {
 		
 		return candleCallbacks.removeCallback(symbol, callback);
 	}
@@ -248,7 +248,7 @@ public class QuoteManager {
 	 * @param symbol
 	 * @param ticksArray
 	 */
-	public void handleCandlestickList(final BitfinexCandlestickSymbol symbol, final List<Tick> ticksBuffer) {
+	public void handleCandlestickList(final BitfinexCandlestickSymbol symbol, final List<Bar> ticksBuffer) {
 		candleCallbacks.handleEventsList(symbol, ticksBuffer);
 	}
 	
@@ -257,7 +257,7 @@ public class QuoteManager {
 	 * @param symbol
 	 * @param tick
 	 */
-	public void handleNewCandlestick(final BitfinexCandlestickSymbol currencyPair, final Tick tick) {
+	public void handleNewCandlestick(final BitfinexCandlestickSymbol currencyPair, final Bar tick) {
 		
 		synchronized (lastTick) {
 			lastTick.put(currencyPair, tick);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
@@ -22,7 +22,7 @@ import java.util.function.BiConsumer;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.ta4j.core.Tick;
+import org.ta4j.core.Bar;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
@@ -175,7 +175,7 @@ public class IntegrationTest {
 			
 			final QuoteManager orderbookManager = bitfinexClient.getQuoteManager();
 			
-			final BiConsumer<BitfinexCandlestickSymbol, Tick> callback = (c, o) -> {
+			final BiConsumer<BitfinexCandlestickSymbol, Bar> callback = (c, o) -> {
 				latch.countDown();
 			};
 			
@@ -250,7 +250,7 @@ public class IntegrationTest {
 			
 			final QuoteManager orderbookManager = bitfinexClient.getQuoteManager();
 			
-			final BiConsumer<BitfinexTickerSymbol, Tick> callback = (c, o) -> {
+			final BiConsumer<BitfinexTickerSymbol, Bar> callback = (c, o) -> {
 				latch.countDown();
 			};
 			
@@ -317,7 +317,7 @@ public class IntegrationTest {
 		// Await at least 2 callbacks
 		final CountDownLatch latch = new CountDownLatch(2);
 		
-		final BiConsumer<BitfinexTickerSymbol, Tick> callback = (c, o) -> {
+		final BiConsumer<BitfinexTickerSymbol, Bar> callback = (c, o) -> {
 			latch.countDown();
 		};
 		


### PR DESCRIPTION
Ta4j changed the names from Ticks to Bars. 

Just completing the naming changes and bumping the version, because there are major improvements and indicator fixes in that version.