### PR TITLE
Changed all double values (amounts, prices, rates, etc.) to BigDecima…

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexOrderBuilder.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexOrderBuilder.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2;
 
+import java.math.BigDecimal;
+
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrder;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderType;
@@ -25,17 +27,17 @@ public class BitfinexOrderBuilder {
 
 	private final BitfinexCurrencyPair symbol; 
 	private final BitfinexOrderType type;
-	private final double amount;
+	private final BigDecimal amount;
 	
-	private double price = -1;
-	private double priceTrailing = -1;
-	private double priceAuxLimit = -1;
+	private BigDecimal price = BigDecimal.valueOf(-1);
+	private BigDecimal priceTrailing = BigDecimal.valueOf(-1);
+	private BigDecimal priceAuxLimit = BigDecimal.valueOf(-1);
 	private boolean postOnly = false;
 	private boolean hidden = false;
 	private int groupid = -1;
 
 	private BitfinexOrderBuilder(final BitfinexCurrencyPair symbol, final BitfinexOrderType type, 
-			final double amount) {
+			BigDecimal amount) {
 		
 		this.symbol = symbol;
 		this.type = type;
@@ -45,7 +47,13 @@ public class BitfinexOrderBuilder {
 	public static BitfinexOrderBuilder create(final BitfinexCurrencyPair symbol, final BitfinexOrderType type, 
 			final double amount) {
 		
-		return new BitfinexOrderBuilder(symbol, type, amount);
+		return new BitfinexOrderBuilder(symbol, type, BigDecimal.valueOf(amount));
+	}
+	
+	public static BitfinexOrderBuilder create(final BitfinexCurrencyPair symbol, final BitfinexOrderType type, 
+			String amount) {
+		
+		return new BitfinexOrderBuilder(symbol, type, new BigDecimal(amount));
 	}
 	
 	public BitfinexOrderBuilder setHidden() {
@@ -58,18 +66,51 @@ public class BitfinexOrderBuilder {
 		return this;
 	}
 	
+	@Deprecated
 	public BitfinexOrderBuilder withPrice(final double price) {
+		this.price = BigDecimal.valueOf(price);
+		return this;
+	}
+	
+	public BitfinexOrderBuilder withPrice(BigDecimal price) {
 		this.price = price;
 		return this;
 	}
 	
+	public BitfinexOrderBuilder withPrice(String price) {
+		this.price = new BigDecimal(price);
+		return this;
+	}
+	
+	@Deprecated
 	public BitfinexOrderBuilder withPriceTrailing(final double price) {
+		this.priceTrailing = BigDecimal.valueOf(price);
+		return this;
+	}
+	
+	public BitfinexOrderBuilder withPriceTrailing(BigDecimal price) {
 		this.priceTrailing = price;
 		return this;
 	}
 	
+	public BitfinexOrderBuilder withPriceTrailing(String price) {
+		this.priceTrailing = new BigDecimal(price);
+		return this;
+	}
+	
+	@Deprecated
 	public BitfinexOrderBuilder withPriceAuxLimit(final double price) {
+		this.priceAuxLimit = BigDecimal.valueOf(price);
+		return this;
+	}
+	
+	public BitfinexOrderBuilder withPriceAuxLimit(BigDecimal price) {
 		this.priceAuxLimit = price;
+		return this;
+	}
+	
+	public BitfinexOrderBuilder withPriceAuxLimit(String price) {
+		this.priceAuxLimit = new BigDecimal(price);
 		return this;
 	}
 	

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/OrderHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/OrderHandler.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.api;
 
+import java.math.BigDecimal;
 import java.util.concurrent.CountDownLatch;
 
 import org.json.JSONArray;
@@ -92,17 +93,17 @@ public class OrderHandler implements APICallbackHandler {
 		exchangeOrder.setSymbol(order.getString(3));
 		exchangeOrder.setCreated(order.getLong(4));
 		exchangeOrder.setUpdated(order.getLong(5));
-		exchangeOrder.setAmount(order.getDouble(6));
-		exchangeOrder.setAmountAtCreation(order.getDouble(7));
+		exchangeOrder.setAmount(order.getBigDecimal(6));
+		exchangeOrder.setAmountAtCreation(order.getBigDecimal(7));
 		exchangeOrder.setOrderType(BitfinexOrderType.fromString(order.getString(8)));
 		
 		final ExchangeOrderState orderState = ExchangeOrderState.fromString(order.getString(13));
 		exchangeOrder.setState(orderState);
 		
-		exchangeOrder.setPrice(order.getDouble(16));
-		exchangeOrder.setPriceAvg(order.optDouble(17, -1));
-		exchangeOrder.setPriceTrailing(order.optDouble(18, -1));
-		exchangeOrder.setPriceAuxLimit(order.optDouble(19, -1));
+		exchangeOrder.setPrice(order.optBigDecimal(16, BigDecimal.valueOf(-1)));
+		exchangeOrder.setPriceAvg(order.optBigDecimal(17, BigDecimal.valueOf(-1)));
+		exchangeOrder.setPriceTrailing(order.optBigDecimal(18, BigDecimal.valueOf(-1)));
+		exchangeOrder.setPriceAuxLimit(order.optBigDecimal(19, BigDecimal.valueOf(-1)));
 		exchangeOrder.setNotify(order.getInt(23) == 1 ? true : false);
 		exchangeOrder.setHidden(order.getInt(24) == 1 ? true : false);
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/PositionHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/PositionHandler.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.api;
 
+import java.math.BigDecimal;
 import java.util.concurrent.CountDownLatch;
 
 import org.json.JSONArray;
@@ -87,14 +88,14 @@ public class PositionHandler implements APICallbackHandler {
 				
 		final Position position = new Position(currency);
 		position.setStatus(positions.getString(1));
-		position.setAmount(positions.getDouble(2));
-		position.setBasePrice(positions.getDouble(3));
-		position.setMarginFunding(positions.getDouble(4));
-		position.setMarginFundingType(positions.getDouble(5));
-		position.setPl(positions.optDouble(6, -1));
-		position.setPlPercent(positions.optDouble(7, -1));
-		position.setPriceLiquidation(positions.optDouble(8, -1));
-		position.setLeverage(positions.optDouble(9, -1));
+		position.setAmount(positions.getBigDecimal(2));
+		position.setBasePrice(positions.getBigDecimal(3));
+		position.setMarginFunding(positions.getBigDecimal(4));
+		position.setMarginFundingType(positions.getBigDecimal(5));
+		position.setPl(positions.optBigDecimal(6, BigDecimal.valueOf(-1)));
+		position.setPlPercent(positions.optBigDecimal(7, BigDecimal.valueOf(-1)));
+		position.setPriceLiquidation(positions.optBigDecimal(8, BigDecimal.valueOf(-1)));
+		position.setLeverage(positions.optBigDecimal(9, BigDecimal.valueOf(-1)));
 				
 		bitfinexApiBroker.getPositionManager().updatePosition(position);
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/TradeHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/TradeHandler.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.api;
 
+import java.math.BigDecimal;
+
 import org.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,8 +71,8 @@ public class TradeHandler implements APICallbackHandler {
 		trade.setCurrency(BitfinexCurrencyPair.fromSymbolString(jsonTrade.getString(1)));
 		trade.setMtsCreate(jsonTrade.getLong(2));
 		trade.setOrderId(jsonTrade.getLong(3));
-		trade.setExecAmount(jsonTrade.getFloat(4));
-		trade.setExecPrice(jsonTrade.getFloat(5));
+		trade.setExecAmount(jsonTrade.getBigDecimal(4));
+		trade.setExecPrice(jsonTrade.getBigDecimal(5));
 		
 		final String orderTypeString = jsonTrade.optString(6, null);
 		
@@ -78,9 +80,9 @@ public class TradeHandler implements APICallbackHandler {
 			trade.setOrderType(BitfinexOrderType.fromString(orderTypeString));
 		}
 		
-		trade.setOrderPrice(jsonTrade.optFloat(7, -1));
+		trade.setOrderPrice(jsonTrade.optBigDecimal(7, BigDecimal.valueOf(-1)));
 		trade.setMaker(jsonTrade.getInt(8) == 1 ? true : false);
-		trade.setFee(jsonTrade.optFloat(9, -1));
+		trade.setFee(jsonTrade.optBigDecimal(9, BigDecimal.valueOf(-1)));
 		trade.setFeeCurrency(jsonTrade.optString(10, ""));
 
 		bitfinexApiBroker.getTradeManager().updateTrade(trade);

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/WalletHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/api/WalletHandler.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.api;
 
+import java.math.BigDecimal;
 import java.util.concurrent.CountDownLatch;
 
 import org.json.JSONArray;
@@ -70,9 +71,9 @@ public class WalletHandler implements APICallbackHandler {
 	private void handleWalletcallback(final BitfinexApiBroker bitfinexApiBroker, final JSONArray walletArray) throws APIException {
 		final String walletType = walletArray.getString(0);
 		final String currency = walletArray.getString(1);
-		final double balance = walletArray.getDouble(2);
-		final double unsettledInterest = walletArray.getDouble(3);
-		final double balanceAvailable = walletArray.optDouble(4, -1);
+		final BigDecimal balance = walletArray.getBigDecimal(2);
+		final BigDecimal unsettledInterest = walletArray.getBigDecimal(3);
+		final BigDecimal balanceAvailable = walletArray.optBigDecimal(4, BigDecimal.valueOf(-1));
 		
 		final Wallet wallet = new Wallet(walletType, currency, balance, unsettledInterest, balanceAvailable);
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/CandlestickHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/CandlestickHandler.java
@@ -17,6 +17,7 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.channel;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -66,11 +67,11 @@ public class CandlestickHandler implements ChannelCallbackHandler {
 		
 		// 0 = Timestamp, 1 = Open, 2 = Close, 3 = High, 4 = Low,  5 = Volume
 		final long timestamp = parts.getLong(0);
-		final double open = parts.getDouble(1);
-		final double close = parts.getDouble(2);
-		final double high = parts.getDouble(3);
-		final double low = parts.getDouble(4);
-		final double volume = parts.getDouble(5);
+		final BigDecimal open = parts.getBigDecimal(1);
+		final BigDecimal close = parts.getBigDecimal(2);
+		final BigDecimal high = parts.getBigDecimal(3);
+		final BigDecimal low = parts.getBigDecimal(4);
+		final BigDecimal volume = parts.getBigDecimal(5);
 		
 		final BitfinexTick tick = new BitfinexTick(timestamp, open, close, high, low, volume);
 		ticksBuffer.add(tick);

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/ExecutedTradeHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/ExecutedTradeHandler.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.channel;
 
+import java.math.BigDecimal;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -68,18 +70,18 @@ public class ExecutedTradeHandler implements ChannelCallbackHandler {
 		final long timestamp = jsonArray.getNumber(1).longValue();
 		executedTrade.setTimestamp(timestamp);
 		
-		final double amount = jsonArray.getNumber(2).doubleValue();
+		final BigDecimal amount = jsonArray.getBigDecimal(2);
 		executedTrade.setAmount(amount);
 		
 		// Funding or Currency
 		if(jsonArray.optNumber(4) != null) {
-			final double rate = jsonArray.getNumber(3).doubleValue();
+			final BigDecimal rate = jsonArray.getBigDecimal(3);
 			executedTrade.setRate(rate);
 			
 			final int period = jsonArray.getNumber(4).intValue();
 			executedTrade.setPeriod(period);
 		} else {
-			final double price = jsonArray.getNumber(3).doubleValue();
+			final BigDecimal price = jsonArray.getBigDecimal(3);
 			executedTrade.setPrice(price);
 		}
 				

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/OrderbookHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/OrderbookHandler.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.channel;
 
+import java.math.BigDecimal;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -61,9 +63,9 @@ public class OrderbookHandler implements ChannelCallbackHandler {
 			final OrderbookConfiguration configuration,
 			final JSONArray jsonArray) {
 		
-		final double price = jsonArray.getNumber(0).doubleValue();
-		final double count = jsonArray.getNumber(1).doubleValue();
-		final double amount = jsonArray.getNumber(2).doubleValue();
+		final BigDecimal price = jsonArray.getBigDecimal(0);
+		final BigDecimal count = jsonArray.getBigDecimal(1);
+		final BigDecimal amount = jsonArray.getBigDecimal(2);
 		
 		final OrderbookEntry orderbookEntry = new OrderbookEntry(price, count, amount);
 		

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/RawOrderbookHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/RawOrderbookHandler.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.channel;
 
+import java.math.BigDecimal;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 
@@ -62,8 +64,8 @@ public class RawOrderbookHandler implements ChannelCallbackHandler {
 			final JSONArray jsonArray) {
 		
 		final long orderId = jsonArray.getNumber(0).longValue();
-		final double price = jsonArray.getNumber(1).doubleValue();
-		final double amount = jsonArray.getNumber(2).doubleValue();
+		final BigDecimal price = jsonArray.getBigDecimal(1);
+		final BigDecimal amount = jsonArray.getBigDecimal(2);
 		
 		final RawOrderbookEntry orderbookEntry = new RawOrderbookEntry(orderId, price, amount);
 		

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/TickHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/TickHandler.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.callback.channel;
 
+import java.math.BigDecimal;
+
 import org.json.JSONArray;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
@@ -41,7 +43,7 @@ public class TickHandler implements ChannelCallbackHandler {
 		// 0 = BID
 		// 2 = ASK
 		// 6 = Price
-		final double price = jsonArray.getDouble(6);
+		final BigDecimal price = jsonArray.getBigDecimal(6);
 		
 		// Volume is set to 0, because the ticker contains only the daily volume
 		final BitfinexTick tick = new BitfinexTick(System.currentTimeMillis(), price, price, 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/OrderCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/OrderCommand.java
@@ -44,18 +44,18 @@ public class OrderCommand extends AbstractAPICommand {
 		orderJson.put("cid", bitfinexOrder.getCid());
 		orderJson.put("type", bitfinexOrder.getType().getBifinexString());
 		orderJson.put("symbol", bitfinexOrder.getSymbol().toBitfinexString());
-		orderJson.put("amount", Double.toString(bitfinexOrder.getAmount()));
+		orderJson.put("amount",  bitfinexOrder.getAmountAsBigDecimal());
 		
-		if(bitfinexOrder.getPrice() != -1) {
-			orderJson.put("price", Double.toString(bitfinexOrder.getPrice()));
+		if(bitfinexOrder.getPriceAsBigDecimal().doubleValue() != -1) {
+			orderJson.put("price", bitfinexOrder.getPriceAsBigDecimal());
 		}
 
-		if(bitfinexOrder.getPriceTrailing() != -1) {
-			orderJson.put("price_trailing", bitfinexOrder.getPriceTrailing());
+		if(bitfinexOrder.getPriceTrailingAsBigDecimal().doubleValue() != -1) {
+			orderJson.put("price_trailing", bitfinexOrder.getPriceTrailingAsBigDecimal());
 		}
 		
-		if(bitfinexOrder.getPriceAuxLimit() != -1) {
-			orderJson.put("price_aux_limit", bitfinexOrder.getPriceAuxLimit());
+		if(bitfinexOrder.getPriceAuxLimitAsBigDecimal().doubleValue() != -1) {
+			orderJson.put("price_aux_limit", bitfinexOrder.getPriceAuxLimitAsBigDecimal());
 		}
 		
 		if(bitfinexOrder.isHidden()) {

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexOrder.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexOrder.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -44,10 +46,10 @@ public class BitfinexOrder {
 	@Enumerated(EnumType.STRING)
 	private final BitfinexOrderType type;
 	
-	private final double price;
-	private final double priceTrailing;
-	private final double priceAuxLimit;
-	private final double amount;
+	private BigDecimal price;
+	private BigDecimal priceTrailing;
+	private BigDecimal priceAuxLimit;
+	private BigDecimal amount;
 	private final boolean postOnly;
 	private final boolean hidden;
 	private final int groupId;
@@ -62,17 +64,35 @@ public class BitfinexOrder {
 		this.symbol = null;
 		this.apikey = null;
 		this.type = null;
-		this.price = -1;
-		this.priceTrailing = -1;
-		this.priceAuxLimit = -1;
-		this.amount = -1;
+		this.price = BigDecimal.valueOf(-1);
+		this.priceTrailing = BigDecimal.valueOf(-1);
+		this.priceAuxLimit = BigDecimal.valueOf(-1);
+		this.amount = BigDecimal.valueOf(-1);
 		this.postOnly = false;
 		this.hidden = false;
 		this.groupId = -1;
 	}
 	
-	public BitfinexOrder(final BitfinexCurrencyPair symbol, final BitfinexOrderType type, final double price, final double amount,
-			final double priceTrailing, final double priceAuxLimit, final boolean postOnly, final boolean hidden,
+	public BitfinexOrder(final BitfinexCurrencyPair symbol, final BitfinexOrderType type, String price, String amount,
+			String priceTrailing, String priceAuxLimit, final boolean postOnly, final boolean hidden,
+			final int groupId) {
+		
+		// The client ID
+		this.cid = MicroSecondTimestampProvider.getNewTimestamp();
+
+		this.symbol = symbol;
+		this.type = type;
+		this.price = new BigDecimal(price);
+		this.priceTrailing = new BigDecimal(priceTrailing);
+		this.priceAuxLimit = new BigDecimal(priceAuxLimit);
+		this.amount = new BigDecimal(amount);
+		this.postOnly = postOnly;
+		this.hidden = hidden;
+		this.groupId = groupId;
+	}
+	
+	public BitfinexOrder(final BitfinexCurrencyPair symbol, final BitfinexOrderType type, BigDecimal price, BigDecimal amount,
+			BigDecimal priceTrailing, BigDecimal priceAuxLimit, final boolean postOnly, final boolean hidden,
 			final int groupId) {
 		
 		// The client ID
@@ -104,20 +124,40 @@ public class BitfinexOrder {
 		return type;
 	}
 
+	@Deprecated
 	public double getPrice() {
-		return price;
+		return price.doubleValue();
+	}
+	
+	public BigDecimal getPriceAsBigDecimal() {
+		return this.price;
 	}
 
+	@Deprecated
 	public double getPriceTrailing() {
+		return priceTrailing.doubleValue();
+	}
+	
+	public BigDecimal getPriceTrailingAsBigDecimal() {
 		return priceTrailing;
 	}
 
+	@Deprecated
 	public double getPriceAuxLimit() {
+		return priceAuxLimit.doubleValue();
+	}
+	
+	public BigDecimal getPriceAuxLimitAsBigDecimal() {
 		return priceAuxLimit;
 	}
 
+	@Deprecated
 	public double getAmount() {
-		return amount;
+		return amount.doubleValue();
+	}
+	
+	public BigDecimal getAmountAsBigDecimal() {
+		return this.amount;
 	}
 
 	public boolean isPostOnly() {

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexTick.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexTick.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 public class BitfinexTick implements Comparable<BitfinexTick>{
 	
 	/**
@@ -27,40 +29,40 @@ public class BitfinexTick implements Comparable<BitfinexTick>{
 	/**
 	 * The open price
 	 */
-	private final double open;
+	private final BigDecimal open;
 	
 	/**
 	 * The close price
 	 */
-	private final double close;
+	private final BigDecimal close;
 	
 	/**
 	 * The high price
 	 */
-	private final double high;
+	private final BigDecimal high;
 	
 	/**
 	 * The low price
 	 */
-	private final double low;
+	private final BigDecimal low;
 	
 	/**
 	 * The volume
 	 */
-	private final double volume;
+	private final BigDecimal volume;
 	
 	/**
 	 * The invalid volume marker
 	 */
-	public final static double INVALID_VOLUME = -1;
+	public final static BigDecimal INVALID_VOLUME = BigDecimal.valueOf(-1);
 
-	public BitfinexTick(final long timestamp, final double open, final double close, final double high,
-			final double low, final double volume) {
+	public BitfinexTick(final long timestamp, BigDecimal open, BigDecimal close, BigDecimal high,
+			BigDecimal low, BigDecimal volume) {
 		
-		assert (high >= open) : "High needs to be >= open";
-		assert (high >= close) : "High needs to be => close";
-		assert (low <= open) : "Low needs to be <= open";
-		assert (low <= close) : "Low needs to be <= close";
+		assert (high.doubleValue() >= open.doubleValue()) : "High needs to be >= open";
+		assert (high.doubleValue() >= close.doubleValue()) : "High needs to be => close";
+		assert (low.doubleValue() <= open.doubleValue()) : "Low needs to be <= open";
+		assert (low.doubleValue() <= close.doubleValue()) : "Low needs to be <= close";
 
 		this.timestamp = timestamp;
 		this.open = open;
@@ -70,31 +72,64 @@ public class BitfinexTick implements Comparable<BitfinexTick>{
 		this.volume = volume;
 	}
 	
-	public BitfinexTick(final long timestamp, final double open, final double close, final double high, final double low) {
+	public BitfinexTick(final long timestamp, BigDecimal open, BigDecimal close, BigDecimal high, BigDecimal low) {
 		this(timestamp, open, close,  high, low, INVALID_VOLUME);
+	}
+	
+	public BitfinexTick(final long timestamp, String open, String close, String high, String low) {
+		this(timestamp, new BigDecimal(open), new BigDecimal(close), new BigDecimal(high), new BigDecimal(low), INVALID_VOLUME);
+	}
+	
+	public BitfinexTick(final long timestamp, String open, String close, String high, String low, String volume) {
+		this(timestamp, new BigDecimal(open), new BigDecimal(close), new BigDecimal(high), new BigDecimal(low), new BigDecimal(volume));
 	}
 	
 	public long getTimestamp() {
 		return timestamp;
 	}
 
+	@Deprecated
 	public double getOpen() {
+		return open.doubleValue();
+	}
+	
+	public BigDecimal getOpenAsBigDecimal() {
 		return open;
 	}
 
+	@Deprecated
 	public double getClose() {
+		return close.doubleValue();
+	}
+	
+	public BigDecimal getCloseAsBigDecimal() {
 		return close;
 	}
 
+	@Deprecated
 	public double getHigh() {
+		return high.doubleValue();
+	}
+	
+	public BigDecimal getHighAsBigDecimal() {
 		return high;
 	}
 
+	@Deprecated
 	public double getLow() {
+		return low.doubleValue();
+	}
+	
+	public BigDecimal getLowAsBigDecimal() {
 		return low;
 	}
 
+	@Deprecated
 	public double getVolume() {
+		return volume.doubleValue();
+	}
+	
+	public BigDecimal getVolumeAsBigDecimal() {
 		return volume;
 	}
 
@@ -103,16 +138,16 @@ public class BitfinexTick implements Comparable<BitfinexTick>{
 		final int prime = 31;
 		int result = 1;
 		long temp;
-		temp = Double.doubleToLongBits(close);
+		temp = Double.doubleToLongBits(close.doubleValue());
 		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(high);
+		temp = Double.doubleToLongBits(high.doubleValue());
 		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(low);
+		temp = Double.doubleToLongBits(low.doubleValue());
 		result = prime * result + (int) (temp ^ (temp >>> 32));
-		temp = Double.doubleToLongBits(open);
+		temp = Double.doubleToLongBits(open.doubleValue());
 		result = prime * result + (int) (temp ^ (temp >>> 32));
 		result = prime * result + (int) (timestamp ^ (timestamp >>> 32));
-		temp = Double.doubleToLongBits(volume);
+		temp = Double.doubleToLongBits(volume.doubleValue());
 		result = prime * result + (int) (temp ^ (temp >>> 32));
 		return result;
 	}
@@ -126,17 +161,17 @@ public class BitfinexTick implements Comparable<BitfinexTick>{
 		if (getClass() != obj.getClass())
 			return false;
 		BitfinexTick other = (BitfinexTick) obj;
-		if (Double.doubleToLongBits(close) != Double.doubleToLongBits(other.close))
+		if (Double.doubleToLongBits(close.doubleValue()) != Double.doubleToLongBits(other.close.doubleValue()))
 			return false;
-		if (Double.doubleToLongBits(high) != Double.doubleToLongBits(other.high))
+		if (Double.doubleToLongBits(high.doubleValue()) != Double.doubleToLongBits(other.high.doubleValue()))
 			return false;
-		if (Double.doubleToLongBits(low) != Double.doubleToLongBits(other.low))
+		if (Double.doubleToLongBits(low.doubleValue()) != Double.doubleToLongBits(other.low.doubleValue()))
 			return false;
-		if (Double.doubleToLongBits(open) != Double.doubleToLongBits(other.open))
+		if (Double.doubleToLongBits(open.doubleValue()) != Double.doubleToLongBits(other.open.doubleValue()))
 			return false;
 		if (timestamp != other.timestamp)
 			return false;
-		if (Double.doubleToLongBits(volume) != Double.doubleToLongBits(other.volume))
+		if (Double.doubleToLongBits(volume.doubleValue()) != Double.doubleToLongBits(other.volume.doubleValue()))
 			return false;
 		return true;
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/ExchangeOrder.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/ExchangeOrder.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -39,8 +41,8 @@ public class ExchangeOrder {
 	private String symbol;
 	private long created;
 	private long updated;
-	private double amount;
-	private double amountAtCreation;
+	private BigDecimal amount;
+	private BigDecimal amountAtCreation;
 	
 	@Enumerated(EnumType.STRING)
 	private BitfinexOrderType orderType;
@@ -48,10 +50,10 @@ public class ExchangeOrder {
 	@Enumerated(EnumType.STRING)
 	private ExchangeOrderState state;
 	
-	private double price;
-	private double priceAvg;
-	private double priceTrailing;
-	private double priceAuxLimit;
+	private BigDecimal price;
+	private BigDecimal priceAvg;
+	private BigDecimal priceTrailing;
+	private BigDecimal priceAuxLimit;
 	private boolean notify;
 	private boolean hidden;
 
@@ -110,19 +112,37 @@ public class ExchangeOrder {
 		this.updated = updated;
 	}
 
+	@Deprecated
 	public double getAmount() {
-		return amount;
+		return amount.doubleValue();
+	}
+	
+	public BigDecimal getAmountAsBigDecimal() {
+		return this.amount;
 	}
 
 	public void setAmount(final double amount) {
+		this.amount = BigDecimal.valueOf(amount);
+	}
+	
+	public void setAmount(BigDecimal amount) {
 		this.amount = amount;
 	}
 
+	@Deprecated
 	public double getAmountAtCreation() {
-		return amountAtCreation;
+		return amountAtCreation.doubleValue();
+	}
+	
+	public BigDecimal getAmountAtCreationAsBigDecimal() {
+		return this.amountAtCreation;
 	}
 
 	public void setAmountAtCreation(final double amountAtCreation) {
+		this.amountAtCreation = BigDecimal.valueOf(amountAtCreation);
+	}
+		
+	public void setAmountAtCreation(BigDecimal amountAtCreation) {
 		this.amountAtCreation = amountAtCreation;
 	}
 
@@ -142,35 +162,72 @@ public class ExchangeOrder {
 		this.state = state;
 	}
 
+	@Deprecated
 	public double getPrice() {
-		return price;
+		return price.doubleValue();
+	}
+	
+	public BigDecimal getPriceAsBigDecimal() {
+		return this.price;
 	}
 
 	public void setPrice(final double price) {
+		this.price = BigDecimal.valueOf(price);
+	}
+	
+	public void setPrice(BigDecimal price) {
 		this.price = price;
 	}
 
+	@Deprecated
 	public double getPriceAvg() {
-		return priceAvg;
+		return priceAvg.doubleValue();
+	}
+	
+	public BigDecimal getPriceAvgAsBigDecimal() {
+		return this.priceAvg;
 	}
 
 	public void setPriceAvg(final double priceAvg) {
+		this.priceAvg = BigDecimal.valueOf(priceAvg);
+	}
+	
+	
+	public void setPriceAvg(BigDecimal priceAvg) {
 		this.priceAvg = priceAvg;
 	}
 
+	@Deprecated
 	public double getPriceTrailing() {
+		return priceTrailing.doubleValue();
+	}
+	
+	public BigDecimal getPriceTrailingAsBigDecimal() {
 		return priceTrailing;
 	}
 
 	public void setPriceTrailing(final double priceTrailing) {
+		this.priceTrailing = BigDecimal.valueOf(priceTrailing);
+	}
+	
+	public void setPriceTrailing(BigDecimal priceTrailing) {
 		this.priceTrailing = priceTrailing;
 	}
 
+	@Deprecated
 	public double getPriceAuxLimit() {
+		return priceAuxLimit.doubleValue();
+	}
+	
+	public BigDecimal getPriceAuxLimitAsBigDecimal() {
 		return priceAuxLimit;
 	}
 
 	public void setPriceAuxLimit(final double priceAuxLimit) {
+		this.priceAuxLimit = BigDecimal.valueOf(priceAuxLimit);
+	}
+	
+	public void setPriceAuxLimit(BigDecimal priceAuxLimit) {
 		this.priceAuxLimit = priceAuxLimit;
 	}
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/ExecutedTrade.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/ExecutedTrade.java
@@ -17,13 +17,15 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 public class ExecutedTrade {
 	
 	private long id;
 	private long timestamp;
-	private double amount;
-	private double price;
-	private double rate;
+	private BigDecimal amount;
+	private BigDecimal price;
+	private BigDecimal rate;
 	private int period;
 	
 	public ExecutedTrade() {
@@ -37,27 +39,54 @@ public class ExecutedTrade {
 		this.timestamp = timestamp;
 	}
 
+	@Deprecated
 	public double getAmount() {
+		return amount.doubleValue();
+	}
+	
+	public BigDecimal getAmountAsBigDecimal() {
 		return amount;
 	}
 
 	public void setAmount(final double amount) {
-		this.amount = amount;
+		this.amount = BigDecimal.valueOf(amount);
 	}
 
+	public void setAmount(BigDecimal amount) {
+		this.amount = amount;
+	}
+	
+	@Deprecated
 	public double getPrice() {
+		return price.doubleValue();
+	}
+	
+	public BigDecimal getPriceAsBigDecimal() {
 		return price;
 	}
 
 	public void setPrice(final double price) {
+		this.price = BigDecimal.valueOf(price);
+	}
+	
+	public void setPrice(BigDecimal price) {
 		this.price = price;
 	}
 
+	@Deprecated
 	public double getRate() {
+		return rate.doubleValue();
+	}
+	
+	public BigDecimal getRateAsBigDecimal() {
 		return rate;
 	}
 
 	public void setRate(final double rate) {
+		this.rate = BigDecimal.valueOf(rate);
+	}
+	
+	public void setRate(BigDecimal rate) {
 		this.rate = rate;
 	}
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/OrderbookEntry.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/OrderbookEntry.java
@@ -17,27 +17,46 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 public class OrderbookEntry {
-	private final double price;
-	private final double count;
-	private final double amount;
 	
-	public OrderbookEntry(final double price, final double count, final double amount) {
+
+	private final BigDecimal price;
+	private final BigDecimal amount;
+	private final BigDecimal count;
+	
+	public OrderbookEntry(BigDecimal price, BigDecimal count, BigDecimal amount) {
 		this.price = price;
 		this.count = count;
 		this.amount = amount;
 	}
 
+	@Deprecated
 	public double getPrice() {
+		return price.doubleValue();
+	}
+	
+	public BigDecimal getPriceAsBigDecimal() {
 		return price;
 	}
 
-	public double getCount() {
-		return count;
+	@Deprecated
+	public double getAmount() {
+		return amount.doubleValue();
+	}
+	
+	public BigDecimal getAmountAsBigDecimal() {
+		return amount;
 	}
 
-	public double getAmount() {
-		return amount;
+	@Deprecated
+	public double getCount() {
+		return count.doubleValue();
+	}
+	
+	public BigDecimal getCountAsBigDecimal() {
+		return count;
 	}
 
 	@Override

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/Position.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/Position.java
@@ -17,18 +17,20 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 public class Position {
 
 	private final BitfinexCurrencyPair curreny;
 	private String status;
-	private double amount;
-	private double basePrice;
-	private double marginFunding;
-	private double marginFundingType;
-	private double pl;
-	private double plPercent;
-	private double priceLiquidation;
-	private double leverage;
+	private BigDecimal amount;
+	private BigDecimal basePrice;
+	private BigDecimal marginFunding;
+	private BigDecimal marginFundingType;
+	private BigDecimal pl;
+	private BigDecimal plPercent;
+	private BigDecimal priceLiquidation;
+	private BigDecimal leverage;
 	
 	public Position(final BitfinexCurrencyPair curreny) {
 		this.curreny = curreny;
@@ -46,67 +48,140 @@ public class Position {
 		this.status = status;
 	}
 	
+	@Deprecated
 	public double getAmount() {
+		return amount.doubleValue();
+	}
+	
+	public BigDecimal getAmountAsBigDecimal() {
 		return amount;
 	}
 	
 	public void setAmount(final double amount) {
+		this.amount = BigDecimal.valueOf(amount);
+	}
+	
+	public void setAmount(BigDecimal amount) {
 		this.amount = amount;
 	}
 	
+	@Deprecated
 	public double getBasePrice() {
+		return basePrice.doubleValue();
+	}
+	
+	public BigDecimal getBasePriceAsBigDecimal() {
 		return basePrice;
 	}
 	
 	public void setBasePrice(final double basePrice) {
+		this.basePrice = BigDecimal.valueOf(basePrice);
+	}
+	
+	public void setBasePrice(BigDecimal basePrice) {
 		this.basePrice = basePrice;
 	}
 	
+	@Deprecated
 	public double getMarginFunding() {
+		return marginFunding.doubleValue();
+	}
+	
+	public BigDecimal getMarginFundingAsBigDecimal() {
 		return marginFunding;
 	}
 	
 	public void setMarginFunding(final double marginFunding) {
+		this.marginFunding = BigDecimal.valueOf(marginFunding);
+	}
+	
+	public void setMarginFunding(BigDecimal marginFunding) {
 		this.marginFunding = marginFunding;
 	}
 	
+	@Deprecated
 	public double getMarginFundingType() {
+		return marginFundingType.doubleValue();
+	}
+	
+	public BigDecimal getMarginFundingTypeAsBigDecimal() {
 		return marginFundingType;
 	}
 	
 	public void setMarginFundingType(final double marginFundingType) {
+		this.marginFundingType = BigDecimal.valueOf(marginFundingType);
+	}
+	
+	public void setMarginFundingType(BigDecimal marginFundingType) {
 		this.marginFundingType = marginFundingType;
 	}
 	
+	@Deprecated
 	public double getPl() {
+		return pl.doubleValue();
+	}
+	
+	public BigDecimal getPlAsBigDecimal() {
 		return pl;
 	}
 	
+	
 	public void setPl(final double pl) {
+		this.pl = BigDecimal.valueOf(pl);
+	}
+	
+	public void setPl(BigDecimal pl) {
 		this.pl = pl;
 	}
 	
+	@Deprecated
 	public double getPriceLiquidation() {
+		return priceLiquidation.doubleValue();
+	}
+	
+	public BigDecimal getPriceLiquidationAsBigDecimal() {
 		return priceLiquidation;
 	}
 	
 	public void setPriceLiquidation(final double priceLiquidation) {
+		this.priceLiquidation = BigDecimal.valueOf(priceLiquidation);
+	}
+	
+	public void setPriceLiquidation(BigDecimal priceLiquidation) {
 		this.priceLiquidation = priceLiquidation;
 	}
 	
+	@Deprecated
 	public double getLeverage() {
+		return leverage.doubleValue();
+	}
+	
+	public BigDecimal getLeverageAsBigDecimal() {
 		return leverage;
 	}
 	
 	public void setLeverage(final double leverage) {
+		this.leverage = BigDecimal.valueOf(leverage);
+	}
+	
+	public void setLeverage(BigDecimal leverage) {
 		this.leverage = leverage;
 	}
 
+	@Deprecated
 	public double getPlPercent() {
+		return plPercent.doubleValue();
+	}
+	
+	public BigDecimal getPlPercentAsBigDecimal() {
 		return plPercent;
 	}
 
 	public void setPlPercent(final double plPercent) {
+		this.plPercent = BigDecimal.valueOf(plPercent);
+	}
+	
+	public void setPlPercent(BigDecimal plPercent) {
 		this.plPercent = plPercent;
 	}
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/RawOrderbookEntry.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/RawOrderbookEntry.java
@@ -17,27 +17,39 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 public class RawOrderbookEntry {
 
 	private final long orderId;
-	private final double price;
-	private final double amount;
+	private final BigDecimal price;
+	private final BigDecimal amount;
 
-	public RawOrderbookEntry(final long orderId, final double price, final double amount) {
+	public RawOrderbookEntry(final long orderId, BigDecimal price, BigDecimal amount) {
 		this.orderId = orderId;
 		this.price = price;
 		this.amount = amount;
 	}
 
-	public double getOrderId() {
+	public long getOrderId() {
 		return orderId;
 	}
 
+	@Deprecated
 	public double getPrice() {
+		return price.doubleValue();
+	}
+	
+	public BigDecimal getPriceAsBigDecimal() {
 		return price;
 	}
 
+	@Deprecated
 	public double getAmount() {
+		return amount.doubleValue();
+	}
+	
+	public BigDecimal getAmountAsBigDecimal() {
 		return amount;
 	}
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/Trade.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/Trade.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -40,15 +42,15 @@ public class Trade {
 	private BitfinexCurrencyPair currency;
 	private long mtsCreate;
 	private long orderId;
-	private double execAmount;
-	private double execPrice;
+	private BigDecimal execAmount;
+	private BigDecimal execPrice;
 	
 	@Enumerated(EnumType.STRING)
 	private BitfinexOrderType orderType;	
 	
-	private double orderPrice;
+	private BigDecimal orderPrice;
 	private boolean maker;
-	private double fee;
+	private BigDecimal fee;
 	private String feeCurrency;
 
 	/**
@@ -90,19 +92,37 @@ public class Trade {
 		this.orderId = orderId;
 	}
 
+	@Deprecated
 	public double getExecAmount() {
-		return execAmount;
+		return execAmount.doubleValue();
+	}
+	
+	public BigDecimal getExecAmountAsBigDecimal() {
+		return this.execAmount;
 	}
 
 	public void setExecAmount(final double execAmount) {
+		this.execAmount = BigDecimal.valueOf(execAmount);
+	}
+	
+	public void setExecAmount(BigDecimal execAmount) {
 		this.execAmount = execAmount;
 	}
 
+	@Deprecated
 	public double getExecPrice() {
-		return execPrice;
+		return execPrice.doubleValue();
+	}
+	
+	public BigDecimal getExecPriceAsBigDecimal() {
+		return this.execPrice;
 	}
 
 	public void setExecPrice(final double execPrice) {
+		this.execPrice = BigDecimal.valueOf(execPrice);
+	}
+	
+	public void setExecPrice(BigDecimal execPrice) {
 		this.execPrice = execPrice;
 	}
 
@@ -114,11 +134,20 @@ public class Trade {
 		this.orderType = orderType;
 	}
 
+	@Deprecated
 	public double getOrderPrice() {
-		return orderPrice;
+		return orderPrice.doubleValue();
+	}
+	
+	public BigDecimal getOrderPriceAsBigDecimal() {
+		return this.orderPrice;
 	}
 
 	public void setOrderPrice(final double orderPrice) {
+		this.orderPrice = BigDecimal.valueOf(orderPrice);
+	}
+	
+	public void setOrderPrice(BigDecimal orderPrice) {
 		this.orderPrice = orderPrice;
 	}
 
@@ -130,11 +159,20 @@ public class Trade {
 		this.maker = maker;
 	}
 
+	@Deprecated
 	public double getFee() {
-		return fee;
+		return fee.doubleValue();
 	}
 
+	public BigDecimal getFeeAsBigDecimal() {
+		return this.fee;
+	}
+	
 	public void setFee(final double fee) {
+		this.fee = BigDecimal.valueOf(fee);
+	}
+	
+	public void setFee(BigDecimal fee) {
 		this.fee = fee;
 	}
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/Wallet.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/Wallet.java
@@ -17,13 +17,15 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.entity;
 
+import java.math.BigDecimal;
+
 public class Wallet {
 
 	private final String walletType;
 	private final String curreny;
-	private final double balance;
-	private final double unsettledInterest;
-	private final double balanceAvailable;
+	private final BigDecimal balance;
+	private final BigDecimal unsettledInterest;
+	private final BigDecimal balanceAvailable;
 	
 	public final static String WALLET_TYPE_EXCHANGE = "exchange";
 	
@@ -31,8 +33,8 @@ public class Wallet {
 	
 	public final static String WALLET_TYPE_FUNDING = "funding";
 
-	public Wallet(final String walletType, final String curreny, final double balance, 
-			final double unsettledInterest, final double balanceAvailable) {
+	public Wallet(final String walletType, final String curreny, BigDecimal balance, 
+			BigDecimal unsettledInterest, BigDecimal balanceAvailable) {
 		
 		this.walletType = walletType;
 		this.curreny = curreny;
@@ -55,15 +57,30 @@ public class Wallet {
 		return curreny;
 	}
 
+	@Deprecated
 	public double getBalance() {
+		return balance.doubleValue();
+	}
+	
+	public BigDecimal getBalanceAsBigDecimal() {
 		return balance;
 	}
 
+	@Deprecated
 	public double getUnsettledInterest() {
+		return unsettledInterest.doubleValue();
+	}
+	
+	public BigDecimal getUnsettledInterestAsBigDecimal() {
 		return unsettledInterest;
 	}
 
+	@Deprecated
 	public double getBalanceAvailable() {
+		return balanceAvailable.doubleValue();
+	}
+	
+	public BigDecimal getBalanceAvailableAsBigDecimal() {
 		return balanceAvailable;
 	}
 

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/BitfinexTickTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/BitfinexTickTest.java
@@ -31,9 +31,9 @@ public class BitfinexTickTest {
 
 	@Test
 	public void testEquals() {
-		final BitfinexTick tick1 = new BitfinexTick(210, 11, 16, 18, 10, 45);
-		final BitfinexTick tick2 = new BitfinexTick(213, 12, 15, 18, 10);
-		final BitfinexTick tick3 = new BitfinexTick(213, 12, 15, 18, 10);
+		final BitfinexTick tick1 = new BitfinexTick(210, "11", "16", "18", "10", "45");
+		final BitfinexTick tick2 = new BitfinexTick(213, "12", "15", "18", "10");
+		final BitfinexTick tick3 = new BitfinexTick(213, "12", "15", "18", "10");
 		
 		Assert.assertEquals(tick2, tick3);
 		Assert.assertEquals(tick2.hashCode(), tick3.hashCode());
@@ -44,14 +44,14 @@ public class BitfinexTickTest {
 	
 	@Test
 	public void testToString() {
-		final BitfinexTick tick1 = new BitfinexTick(213, 12, 15, 18, 12);
+		final BitfinexTick tick1 = new BitfinexTick(213, "12", "15", "18", "12");
 		Assert.assertTrue(tick1.toString().length() > 10);
 	}
 	
 	@Test
 	public void testCompareTo() {
-		final BitfinexTick tick1 = new BitfinexTick(210, 11, 16, 18, 10);
-		final BitfinexTick tick2 = new BitfinexTick(213, 12, 15, 18, 12);
+		final BitfinexTick tick1 = new BitfinexTick(210, "11", "16", "18", "10");
+		final BitfinexTick tick2 = new BitfinexTick(213, "12", "15", "18", "12");
 		Assert.assertTrue(tick1.compareTo(tick2) < 0);
 		Assert.assertTrue(tick2.compareTo(tick1) > 0);
 		Assert.assertTrue(tick1.compareTo(tick1) == 0);
@@ -59,16 +59,16 @@ public class BitfinexTickTest {
 	
 	@Test
 	public void testGetter() {
-		final BitfinexTick tick1 = new BitfinexTick(210, 11, 16, 18, 10, 45);
-		final BitfinexTick tick2 = new BitfinexTick(213, 12, 15, 18, 12);
+		final BitfinexTick tick1 = new BitfinexTick(210, "11", "16", "18", "10", "45");
+		final BitfinexTick tick2 = new BitfinexTick(213, "12", "15", "18", "12");
 		
 		Assert.assertEquals(210, tick1.getTimestamp());
-		Assert.assertEquals(11, tick1.getOpen(), DELTA);
-		Assert.assertEquals(16, tick1.getClose(), DELTA);
-		Assert.assertEquals(18, tick1.getHigh(), DELTA);
-		Assert.assertEquals(10, tick1.getLow(), DELTA);
-		Assert.assertEquals(45, tick1.getVolume(), DELTA);
+		Assert.assertEquals(11, tick1.getOpenAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(16, tick1.getCloseAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(18, tick1.getHighAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(10, tick1.getLowAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(45, tick1.getVolumeAsBigDecimal().doubleValue(), DELTA);
 
-		Assert.assertEquals(BitfinexTick.INVALID_VOLUME, tick2.getVolume(), DELTA);
+		Assert.assertEquals(BitfinexTick.INVALID_VOLUME.doubleValue(), tick2.getVolumeAsBigDecimal().doubleValue(), DELTA);
 	}
 }

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CandlestickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CandlestickHandlerTest.java
@@ -66,11 +66,11 @@ public class CandlestickHandlerTest {
 		tickerManager.registerCandlestickCallback(symbol, (s, c) -> {
 			counter.incrementAndGet();
 			Assert.assertEquals(symbol, s);
-			Assert.assertEquals(15996, c.getOpen(), DELTA);
-			Assert.assertEquals(15997, c.getClose(), DELTA);
-			Assert.assertEquals(16000, c.getHigh(), DELTA);
-			Assert.assertEquals(15980, c.getLow(), DELTA);
-			Assert.assertEquals(318.5139342, c.getVolume(), DELTA);
+			Assert.assertEquals(15996, c.getOpenAsBigDecimal().doubleValue(), DELTA);
+			Assert.assertEquals(15997, c.getCloseAsBigDecimal().doubleValue(), DELTA);
+			Assert.assertEquals(16000, c.getHighAsBigDecimal().doubleValue(), DELTA);
+			Assert.assertEquals(15980, c.getLowAsBigDecimal().doubleValue(), DELTA);
+			Assert.assertEquals(318.5139342, c.getVolumeAsBigDecimal().doubleValue(), DELTA);
 		});
 						
 		final CandlestickHandler candlestickHandler = new CandlestickHandler();
@@ -105,17 +105,17 @@ public class CandlestickHandlerTest {
 			Assert.assertEquals(symbol, s);
 			final int counterValue = counter.getAndIncrement();
 			if(counterValue == 0) {
-				Assert.assertEquals(15996, c.getOpen(), DELTA);
-				Assert.assertEquals(15997, c.getClose(), DELTA);
-				Assert.assertEquals(16000, c.getHigh(), DELTA);
-				Assert.assertEquals(15980, c.getLow(), DELTA);
-				Assert.assertEquals(318.5139342, c.getVolume(), DELTA);
+				Assert.assertEquals(15996, c.getOpenAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(15997, c.getCloseAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(16000, c.getHighAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(15980, c.getLowAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(318.5139342, c.getVolumeAsBigDecimal().doubleValue(), DELTA);
 			} else if(counterValue == 1) {
-				Assert.assertEquals(15899, c.getOpen(), DELTA);
-				Assert.assertEquals(15996, c.getClose(), DELTA);
-				Assert.assertEquals(16097, c.getHigh(), DELTA);
-				Assert.assertEquals(15890, c.getLow(), DELTA);
-				Assert.assertEquals(1137.180342268, c.getVolume(), DELTA);
+				Assert.assertEquals(15899, c.getOpenAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(15996, c.getCloseAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(16097, c.getHighAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(15890, c.getLowAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(1137.180342268, c.getVolumeAsBigDecimal().doubleValue(), DELTA);
 			} else {
 				throw new IllegalArgumentException("Illegal call, expected 2 candlesticks");
 			}

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
@@ -89,9 +89,9 @@ public class CommandsTest {
 			= BitfinexOrderBuilder.create(BitfinexCurrencyPair.BCH_USD, BitfinexOrderType.EXCHANGE_STOP, 2)
 			.setHidden()
 			.setPostOnly()
-			.withPrice(12)
-			.withPriceAuxLimit(23)
-			.withPriceTrailing(23)
+			.withPrice("12")
+			.withPriceAuxLimit("23")
+			.withPriceTrailing("23")
 			.withGroupId(4)
 			.build();
 		

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/ExecutedTradesHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/ExecutedTradesHandlerTest.java
@@ -67,8 +67,8 @@ public class ExecutedTradesHandlerTest {
 				Assert.assertEquals(symbol, s);
 				Assert.assertEquals(190631057, c.getId());
 				Assert.assertEquals(1518037080162l, c.getTimestamp());
-				Assert.assertEquals(0.007, c.getAmount(), DELTA);
-				Assert.assertEquals(8175.9, c.getPrice(), DELTA);
+				Assert.assertEquals(0.007, c.getAmountAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(8175.9, c.getPriceAsBigDecimal().doubleValue(), DELTA);
 				latch.countDown();
 			} catch (Throwable e) {
 				e.printStackTrace();
@@ -109,13 +109,13 @@ public class ExecutedTradesHandlerTest {
 				if(c.getId() == 190631057) {
 					Assert.assertEquals(190631057, c.getId());
 					Assert.assertEquals(1518037080162l, c.getTimestamp());
-					Assert.assertEquals(0.007, c.getAmount(), DELTA);
-					Assert.assertEquals(8175.9, c.getPrice(), DELTA);
+					Assert.assertEquals(0.007, c.getAmountAsBigDecimal().doubleValue(), DELTA);
+					Assert.assertEquals(8175.9, c.getPriceAsBigDecimal().doubleValue(), DELTA);
 				} else if(c.getId() == 190631052) {
 					Assert.assertEquals(190631052, c.getId());
 					Assert.assertEquals(1518037080110l, c.getTimestamp());
-					Assert.assertEquals(-0.25, c.getAmount(), DELTA);
-					Assert.assertEquals(8175.8, c.getPrice(), DELTA);
+					Assert.assertEquals(-0.25, c.getAmountAsBigDecimal().doubleValue(), DELTA);
+					Assert.assertEquals(8175.8, c.getPriceAsBigDecimal().doubleValue(), DELTA);
 				} else {
 					throw new IllegalArgumentException("Illegal call, expected 2 trades");
 				}

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
@@ -92,9 +92,9 @@ public class IntegrationTest {
 			final OrderbookManager orderbookManager = bitfinexClient.getOrderbookManager();
 			
 			final BiConsumer<OrderbookConfiguration, OrderbookEntry> callback = (c, o) -> {
-				Assert.assertTrue(o.getAmount() != 0);
-				Assert.assertTrue(o.getPrice() != 0);
-				Assert.assertTrue(o.getCount() != 0);
+				Assert.assertTrue(o.getAmountAsBigDecimal().doubleValue() != 0);
+				Assert.assertTrue(o.getPriceAsBigDecimal().doubleValue() != 0);
+				Assert.assertTrue(o.getCountAsBigDecimal().doubleValue() != 0);
 				Assert.assertTrue(o.toString().length() > 0);
 				latch.countDown();
 			};
@@ -134,8 +134,8 @@ public class IntegrationTest {
 			final RawOrderbookManager rawOrderbookManager = bitfinexClient.getRawOrderbookManager();
 			
 			final BiConsumer<RawOrderbookConfiguration, RawOrderbookEntry> callback = (c, o) -> {
-				Assert.assertTrue(o.getAmount() != 0);
-				Assert.assertTrue(o.getPrice() != 0);
+				Assert.assertTrue(o.getAmountAsBigDecimal().doubleValue() != 0);
+				Assert.assertTrue(o.getPriceAsBigDecimal().doubleValue() != 0);
 				Assert.assertTrue(o.getOrderId() >= 0);
 				Assert.assertTrue(o.toString().length() > 0);
 				latch.countDown();

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/TickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/TickHandlerTest.java
@@ -68,11 +68,11 @@ public class TickHandlerTest {
 			
 			try {
 				Assert.assertEquals(symbol, s);
-				Assert.assertEquals(26129, c.getOpen(), DELTA);
-				Assert.assertEquals(26129, c.getClose(), DELTA);
-				Assert.assertEquals(26129, c.getHigh(), DELTA);
-				Assert.assertEquals(26129, c.getLow(), DELTA);
-				Assert.assertEquals(BitfinexTick.INVALID_VOLUME, c.getVolume(), DELTA);
+				Assert.assertEquals(26129, c.getOpenAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(26129, c.getCloseAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(26129, c.getHighAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(26129, c.getLowAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(BitfinexTick.INVALID_VOLUME.doubleValue(), c.getVolumeAsBigDecimal().doubleValue(), DELTA);
 			} catch(Throwable e) {
 				System.out.println(e);
 				throw e;

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/TradeManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/TradeManagerTest.java
@@ -69,8 +69,8 @@ public class TradeManagerTest {
 				Assert.assertEquals(BitfinexCurrencyPair.BTC_USD, t.getCurrency());
 				Assert.assertEquals(1512247319827l, t.getMtsCreate());
 				Assert.assertEquals(5691690918l, t.getOrderId());
-				Assert.assertEquals(-0.002, t.getExecAmount(), DELTA);
-				Assert.assertEquals(10894, t.getExecPrice(), DELTA);
+				Assert.assertEquals(-0.002, t.getExecAmountAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(10894, t.getExecPriceAsBigDecimal().doubleValue(), DELTA);
 
 				Assert.assertTrue(t.toString().length() > 0);
 			} catch (Throwable e) {
@@ -109,12 +109,12 @@ public class TradeManagerTest {
 				Assert.assertEquals(BitfinexCurrencyPair.BTC_USD, t.getCurrency());
 				Assert.assertEquals(1512247319827l, t.getMtsCreate());
 				Assert.assertEquals(5691690918l, t.getOrderId());
-				Assert.assertEquals(-0.002, t.getExecAmount(), DELTA);
-				Assert.assertEquals(10894, t.getExecPrice(), DELTA);
+				Assert.assertEquals(-0.002, t.getExecAmountAsBigDecimal().doubleValue(), DELTA);
+				Assert.assertEquals(10894, t.getExecPriceAsBigDecimal().doubleValue(), DELTA);
 				Assert.assertEquals(BitfinexOrderType.EXCHANGE_MARKET, t.getOrderType());
-				Assert.assertEquals(10894, t.getOrderPrice(), DELTA);
+				Assert.assertEquals(10894, t.getOrderPriceAsBigDecimal().doubleValue(), DELTA);
 				Assert.assertFalse(t.isMaker());
-				Assert.assertEquals(-0.0392184, t.getFee(), DELTA);
+				Assert.assertEquals(-0.0392184, t.getFeeAsBigDecimal().doubleValue(), DELTA);
 				Assert.assertEquals("USD", t.getFeeCurrency());
 				Assert.assertTrue(t.toString().length() > 0);
 			} catch (Throwable e) {

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/WalletHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/WalletHandlerTest.java
@@ -68,9 +68,9 @@ public class WalletHandlerTest {
 		walletLatch.await();
 		
 		Assert.assertEquals(1, walletTable.size());
-		Assert.assertEquals(9, walletTable.get("exchange", "ETH").getBalance(), DELTA);
-		Assert.assertEquals(-1, walletTable.get("exchange", "ETH").getBalanceAvailable(), DELTA);
-		Assert.assertEquals(0, walletTable.get("exchange", "ETH").getUnsettledInterest(), DELTA);
+		Assert.assertEquals(9, walletTable.get("exchange", "ETH").getBalanceAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(-1, walletTable.get("exchange", "ETH").getBalanceAvailableAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(0, walletTable.get("exchange", "ETH").getUnsettledInterestAsBigDecimal().doubleValue(), DELTA);
 	}
 	
 	/**
@@ -102,17 +102,17 @@ public class WalletHandlerTest {
 		
 		Assert.assertEquals(9, walletTable.size());
 		
-		Assert.assertEquals(9, walletTable.get("exchange", "ETH").getBalance(), DELTA);
-		Assert.assertEquals(-1, walletTable.get("exchange", "ETH").getBalanceAvailable(), DELTA);
-		Assert.assertEquals(0, walletTable.get("exchange", "ETH").getUnsettledInterest(), DELTA);
+		Assert.assertEquals(9, walletTable.get("exchange", "ETH").getBalanceAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(-1, walletTable.get("exchange", "ETH").getBalanceAvailableAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(0, walletTable.get("exchange", "ETH").getUnsettledInterestAsBigDecimal().doubleValue(), DELTA);
 		
-		Assert.assertEquals(1826.56468323, walletTable.get("exchange", "USD").getBalance(), DELTA);
-		Assert.assertEquals(-1, walletTable.get("exchange", "ETH").getBalanceAvailable(), DELTA);
-		Assert.assertEquals(0, walletTable.get("exchange", "ETH").getUnsettledInterest(), DELTA);
+		Assert.assertEquals(1826.56468323, walletTable.get("exchange", "USD").getBalanceAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(-1, walletTable.get("exchange", "ETH").getBalanceAvailableAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(0, walletTable.get("exchange", "ETH").getUnsettledInterestAsBigDecimal().doubleValue(), DELTA);
 		
-		Assert.assertEquals(0, walletTable.get("margin", "USD").getBalance(), DELTA);
-		Assert.assertEquals(-1, walletTable.get("margin", "USD").getBalanceAvailable(), DELTA);
-		Assert.assertEquals(0, walletTable.get("margin", "USD").getUnsettledInterest(), DELTA);
+		Assert.assertEquals(0, walletTable.get("margin", "USD").getBalanceAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(-1, walletTable.get("margin", "USD").getBalanceAvailableAsBigDecimal().doubleValue(), DELTA);
+		Assert.assertEquals(0, walletTable.get("margin", "USD").getUnsettledInterestAsBigDecimal().doubleValue(), DELTA);
 		
 		Assert.assertTrue(walletTable.get("margin", "USD").toString().length() > 0);
 	}


### PR DESCRIPTION
…l to increase precision

Methods returning doubles are kept for legacy, but marked as deprecated to hint users to switch to the BigDecimal representation in their program as well