### PR TITLE
BitfinexApiBroker: defaultAuthNonceProducer introduced

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -21,12 +21,14 @@ import java.io.Closeable;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -213,6 +215,11 @@ public class BitfinexApiBroker implements Closeable {
 	 * The sequence number auditor
 	 */
 	private final SequenceNumberAuditor sequenceNumberAuditor;
+
+	/**
+	 * default auth nonce producer
+	 */
+	private Supplier<String> defaultAuthNonceProducer = () -> Long.toString(System.currentTimeMillis());
 	
 	/**
 	 * The Logger
@@ -340,7 +347,7 @@ public class BitfinexApiBroker implements Closeable {
 		connectionReadyLatch = new CountDownLatch(CONNECTION_READY_EVENTS);
 
 		if(isAuthenticatedConnection()) {
-			sendCommand(new AuthCommand());
+			sendCommand(new AuthCommand(defaultAuthNonceProducer));
 			logger.info("Waiting for connection ready events");
 			connectionReadyLatch.await(10, TimeUnit.SECONDS);
 			
@@ -967,5 +974,14 @@ public class BitfinexApiBroker implements Closeable {
 	 */
 	public boolean isDeadManFeatureEnabled() {
 		return deadManSwitch;
+	}
+
+	/**
+	 * Sets default auth nonce producer
+	 * @param defaultAuthNonceProducer 	- default nonce producer used for authentication
+	 */
+	public void setDefaultAuthNonceProducer(Supplier<String> defaultAuthNonceProducer) {
+		Objects.requireNonNull(defaultAuthNonceProducer);
+		this.defaultAuthNonceProducer = defaultAuthNonceProducer;
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/AuthCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/AuthCommand.java
@@ -25,9 +25,18 @@ import org.json.JSONObject;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.google.common.io.BaseEncoding;
 
+import java.util.Objects;
+import java.util.function.Supplier;
+
 public class AuthCommand extends AbstractAPICommand {
 
 	private static final String HMAC_SHA1_ALGORITHM = "HmacSHA384";
+	private final Supplier<String> authNonceSupplier;
+
+	public AuthCommand(Supplier<String> authNonceSupplier) {
+		Objects.requireNonNull(authNonceSupplier);
+		this.authNonceSupplier = authNonceSupplier;
+	}
 
 	@Override
 	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
@@ -36,7 +45,7 @@ public class AuthCommand extends AbstractAPICommand {
 			final String APISecret = bitfinexApiBroker.getApiSecret();
 			final boolean deadManSwitch = bitfinexApiBroker.isDeadManFeatureEnabled();
 			
-			final String authNonce = Long.toString(System.currentTimeMillis());
+			final String authNonce = authNonceSupplier.get();
 			final String authPayload = "AUTH" + authNonce;
 
 			final SecretKeySpec signingKey = new SecretKeySpec(APISecret.getBytes(), HMAC_SHA1_ALGORITHM);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
@@ -60,7 +60,7 @@ public class CommandsTest {
 			= new RawOrderbookConfiguration(BitfinexCurrencyPair.of("BAT","BTC"));
 		
 		final List<AbstractAPICommand> commands = Arrays.asList(
-				new AuthCommand(), 
+				new AuthCommand(() -> Long.toString(System.currentTimeMillis())),
 				new CancelOrderCommand(123),
 				new CancelOrderGroupCommand(1),
 				new OrderCommand(order),


### PR DESCRIPTION
System.currentTimeMillis() may return different values on different machines.
Naturally, user should provide unique key per running instance, however, it would be good to leave a way provide more sophisticated nonce generator - if needed.

mb