### PR TITLE
reset latch flags on reconnect

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -745,6 +745,9 @@ public class BitfinexApiBroker implements Closeable {
 			websocketEndpoint.close();
 
 			connectionReadyLatch = new CountDownLatch(CONNECTION_READY_EVENTS);
+			ordersUpdated = false;
+			walletsUpdated = false;
+			positionsUpdated = false;
 			websocketEndpoint.connect();
 			
 			connectionFeatureManager.applyConnectionFeatures();


### PR DESCRIPTION
I've introduced a bug in "reconnect()" scenario - sorry about that.

In longer run, I will refactor that piece of functionality out - flags are only "for now", as I am trying to keep PRs relatively small (and tackling single scope of functionality)