### PR TITLE
BitfinexApiBrokerConfig & BitfinexApiCallbackRegistry introduced

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -21,18 +21,12 @@ import java.io.Closeable;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.Table;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -72,11 +66,8 @@ import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTradesCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.ConnectionCapabilities;
-import com.github.jnidzwetzki.bitfinex.v2.entity.ExchangeOrder;
 import com.github.jnidzwetzki.bitfinex.v2.entity.OrderbookConfiguration;
-import com.github.jnidzwetzki.bitfinex.v2.entity.Position;
 import com.github.jnidzwetzki.bitfinex.v2.entity.RawOrderbookConfiguration;
-import com.github.jnidzwetzki.bitfinex.v2.entity.Wallet;
 import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexCandlestickSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexExecutedTradeSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexStreamSymbol;
@@ -96,17 +87,22 @@ public class BitfinexApiBroker implements Closeable {
 	 * The bitfinex api
 	 */
 	public final static String BITFINEX_URI = "wss://api.bitfinex.com/ws/2";
-	
+
 	/**
-	 * The API callback
+	 * broker configuration
 	 */
-	private final Consumer<String> apiCallback = this::websocketCallback;
-	
+	private final BitfinexApiBrokerConfig configuration;
+
+	/**
+	 * callback registry
+	 */
+	private BitfinexApiCallbackRegistry callbackRegistry;
+
 	/**
 	 * The websocket endpoint
 	 */
 	private WebsocketClientEndpoint websocketEndpoint;
-	
+
 	/**
 	 * The channel map
 	 */
@@ -155,45 +151,13 @@ public class BitfinexApiBroker implements Closeable {
 	/**
 	 * The last heartbeat value
 	 */
-	protected final AtomicLong lastHeatbeat;
+	protected final AtomicLong lastHeartbeat;
 
 	/**
 	 * The heartbeat thread
 	 */
 	private Thread heartbeatThread;
-	
-	/**
-	 * The API key
-	 */
-	private String apiKey;
-	
-	/**
-	 * The API secret
-	 */
-	private String apiSecret;
-	
-	/**
-	 * The dead man switch
-	 */
-	private boolean deadManSwitch = false;
-	
-	/**
-	 * The connection ready latch
-	 */
-	private CountDownLatch connectionReadyLatch;
-	private boolean ordersUpdated;
-	private boolean walletsUpdated;
-	private boolean positionsUpdated;
-	
-	/**
-	 * Event on the latch until the connection is ready
-	 * - Authenticated
-	 * - Order snapshots read
-	 * - Wallet snapshot read
-	 * - Position snapshot read
-	 */
-	private final static int CONNECTION_READY_EVENTS = 4;
-	
+
 	/**
 	 * The capabilities of the connection
 	 */
@@ -215,55 +179,36 @@ public class BitfinexApiBroker implements Closeable {
 	private Map<String, CommandCallbackHandler> commandCallbacks;
 	
 	/**
-	 * The executor service
-	 */
-	private final ExecutorService executorService;
-	
-	/**
 	 * The sequence number auditor
 	 */
 	private final SequenceNumberAuditor sequenceNumberAuditor;
-	
-	/**
-	 * The auth nonce producer
-	 */
-	public Supplier<String> authNonceProducer;
 
-	/**
-	 * The Logger
-	 */
 	private final static Logger logger = LoggerFactory.getLogger(BitfinexApiBroker.class);
 
-	public BitfinexApiBroker(final String apiKey, final String apiSecret, final boolean deadManSwitch) {
-		this(apiKey, apiSecret);
-		this.deadManSwitch = deadManSwitch;
+	public BitfinexApiBroker(BitfinexApiBrokerConfig config) {
+		this(config, new BitfinexApiCallbackRegistry());
 	}
-	
-	public BitfinexApiBroker(final String apiKey, final String apiSecret) {
-		this();
-		this.apiKey = apiKey;
-		this.apiSecret = apiSecret;
-	}
-	
-	public BitfinexApiBroker() {
-		this.executorService = Executors.newFixedThreadPool(10);
-		this.channelIdSymbolMap = new ConcurrentHashMap<>();
-		this.lastHeatbeat = new AtomicLong();
-		this.quoteManager = new QuoteManager(this, executorService);
-		this.orderbookManager = new OrderbookManager(this, executorService);
-		this.rawOrderbookManager = new RawOrderbookManager(this, executorService);
-		this.orderManager = new OrderManager(this, executorService);
-		this.tradeManager = new TradeManager(this, executorService);
-		this.positionManager = new PositionManager(this, executorService);
-		this.walletManager = new WalletManager(this, executorService);
-		this.connectionFeatureManager = new ConnectionFeatureManager(this, executorService);
-		this.capabilities = ConnectionCapabilities.NO_CAPABILITIES;
+
+	public BitfinexApiBroker(BitfinexApiBrokerConfig config, BitfinexApiCallbackRegistry callbackRegistry) {
+		this.configuration = new BitfinexApiBrokerConfig(config);
+		this.callbackRegistry = callbackRegistry;
 		this.channelHandler = new HashMap<>();
+
+		this.channelIdSymbolMap = new ConcurrentHashMap<>();
+		this.capabilities = ConnectionCapabilities.NO_CAPABILITIES;
 		this.sequenceNumberAuditor = new SequenceNumberAuditor();
-		this.authNonceProducer = AuthCommand.AUTH_NONCE_PRODUCER_TIMESTAMP;
-		
-		setupChannelHandler();
-		setupCommandCallbacks();
+		this.lastHeartbeat = new AtomicLong();
+		this.quoteManager = new QuoteManager(this, configuration.getExecutorService(), callbackRegistry);
+		this.orderbookManager = new OrderbookManager(this, configuration.getExecutorService(), callbackRegistry);
+		this.rawOrderbookManager = new RawOrderbookManager(this, configuration.getExecutorService(), callbackRegistry);
+		this.orderManager = new OrderManager(this, configuration.getExecutorService(), callbackRegistry);
+		this.tradeManager = new TradeManager(this, configuration.getExecutorService(), callbackRegistry);
+		this.positionManager = new PositionManager(this, configuration.getExecutorService(), callbackRegistry);
+		this.walletManager = new WalletManager(this, configuration.getExecutorService(), callbackRegistry);
+		this.connectionFeatureManager = new ConnectionFeatureManager(this, configuration.getExecutorService());
+
+        setupChannelHandler();
+        setupCommandCallbacks();
 	}
 
 	/**
@@ -276,15 +221,7 @@ public class BitfinexApiBroker implements Closeable {
 		channelHandler.put("hb", heartbeatHandler);
 
 		final PositionHandler positionHandler = new PositionHandler();
-		positionHandler.onPositionsEvent(positions -> {
-			for (Position position : positions) {
-				positionManager.updatePosition(position);
-			}
-			if (!positionsUpdated) {
-				positionsUpdated = true;
-				connectionReadyLatch.countDown();
-			}
-		});
+		positionHandler.onPositionsEvent(callbackRegistry::acceptPositionsEvent);
 		// Position snapshot
 		channelHandler.put("ps", positionHandler);
 		// Position new
@@ -304,23 +241,7 @@ public class BitfinexApiBroker implements Closeable {
 		channelHandler.put("ats", new DoNothingHandler());
 
 		final WalletHandler walletHandler = new WalletHandler();
-		walletHandler.onWalletsEvent(wallets -> {
-			try {
-				for (Wallet wallet : wallets) {
-					Table<String, String, Wallet> walletTable = walletManager.getWalletTable();
-					synchronized (walletTable) {
-						walletTable.put(wallet.getWalletType(), wallet.getCurreny(), wallet);
-						walletTable.notifyAll();
-					}
-				}
-				if (!walletsUpdated) {
-					walletsUpdated = true;
-					connectionReadyLatch.countDown();
-				}
-			} catch (APIException e) {
-				e.printStackTrace();
-			}
-		});
+		walletHandler.onWalletsEvent(callbackRegistry::acceptWalletsEvent);
 		// Wallet snapshot
 		channelHandler.put("ws", walletHandler);
 		// Wallet update
@@ -328,14 +249,8 @@ public class BitfinexApiBroker implements Closeable {
 
 		final OrderHandler orderHandler = new OrderHandler();
 		orderHandler.onExchangeOrdersEvent(exchangeOrders -> {
-			for (ExchangeOrder exchangeOrder : exchangeOrders) {
-				exchangeOrder.setApikey(getApiKey());
-				orderManager.updateOrder(exchangeOrder);
-			}
-			if (!ordersUpdated) {
-				ordersUpdated = true;
-				connectionReadyLatch.countDown();
-			}
+			exchangeOrders.forEach(eo ->  eo.setApikey(configuration.getApiKey()));
+			callbackRegistry.acceptExchangeOrdersEvent(exchangeOrders);
 		});
 		// Order snapshot
 		channelHandler.put("os", orderHandler);
@@ -348,8 +263,8 @@ public class BitfinexApiBroker implements Closeable {
 
 		final TradeHandler tradeHandler = new TradeHandler();
 		tradeHandler.onTradeEvent(trade -> {
-			trade.setApikey(getApiKey());
-			tradeManager.updateTrade(trade);
+			trade.setApikey(configuration.getApiKey());
+			callbackRegistry.acceptTradeEvent(trade);
 		});
 		// Trade executed
 		channelHandler.put("te", tradeHandler);
@@ -358,8 +273,8 @@ public class BitfinexApiBroker implements Closeable {
 
 		final NotificationHandler notificationHandler = new NotificationHandler();
 		notificationHandler.onExchangeOrderNotification(eo -> {
-			eo.setApikey(getApiKey());
-			orderManager.updateOrder(eo);
+			eo.setApikey(configuration.getApiKey());
+			callbackRegistry.acceptExchangeOrderNotification(eo);
 		});
 		// General notification
 		channelHandler.put("n", notificationHandler);
@@ -372,6 +287,11 @@ public class BitfinexApiBroker implements Closeable {
 		commandCallbacks = new HashMap<>();
 		commandCallbacks.put("info", new DoNothingCommandCallback());
 
+		// TODO: hb is not ping:pong
+		final ConnectionHeartbeatCallback pong = new ConnectionHeartbeatCallback();
+		pong.onHeartbeatEvent(l -> this.updateConnectionHeartbeat());
+		commandCallbacks.put("pong", pong);
+
 		final SubscribedCallback subscribed = new SubscribedCallback();
 		subscribed.onSubscribedEvent((channelId, symbol) -> {
 			synchronized (channelIdSymbolMap) {
@@ -380,11 +300,6 @@ public class BitfinexApiBroker implements Closeable {
 			}
 		});
 		commandCallbacks.put("subscribed", subscribed);
-
-		// TODO: hb is not ping:pong
-		final ConnectionHeartbeatCallback pong = new ConnectionHeartbeatCallback();
-		pong.onHeartbeatEvent(l -> this.updateConnectionHeartbeat());
-		commandCallbacks.put("pong", pong);
 
 		UnsubscribedCallback unsubscribed = new UnsubscribedCallback();
 		unsubscribed.onUnsubscribedChannelEvent(channelId -> {
@@ -396,18 +311,8 @@ public class BitfinexApiBroker implements Closeable {
 		commandCallbacks.put("unsubscribed", unsubscribed);
 
 		final AuthCallback auth = new AuthCallback();
-		auth.onAuthenticationSuccessEvent(c -> {
-			this.capabilities = c;
-			this.authenticated = true;
-			this.connectionReadyLatch.countDown();
-		});
-		auth.onAuthenticationFailedEvent(c -> {
-			this.capabilities = c;
-			this.authenticated = false;
-			while (connectionReadyLatch.getCount() != 0) {
-				this.connectionReadyLatch.countDown();
-			}
-		});
+		auth.onAuthenticationSuccessEvent(callbackRegistry::acceptAuthenticationSuccessEvent);
+		auth.onAuthenticationFailedEvent(callbackRegistry::acceptAuthenticationFailedEvent);
 		commandCallbacks.put("auth", auth);
 
 		final ConfCallback conf = new ConfCallback();
@@ -423,19 +328,50 @@ public class BitfinexApiBroker implements Closeable {
 	public void connect() throws APIException {
 		try {
 			sequenceNumberAuditor.reset();
-			connectionReadyLatch = new CountDownLatch(CONNECTION_READY_EVENTS);
+			CountDownLatch connectionReadyLatch = new CountDownLatch(4);
+
+			Closeable authSuccessEventCallback = callbackRegistry.onAuthenticationSuccessEvent(c -> {
+				capabilities = c;
+				authenticated = true;
+				connectionReadyLatch.countDown();
+			});
+			Closeable authFailedCallback = callbackRegistry.onAuthenticationFailedEvent(c -> {
+				capabilities = c;
+				authenticated = false;
+				while (connectionReadyLatch.getCount() != 0) {
+					connectionReadyLatch.countDown();
+				}
+			});
+			Closeable positionInitCallback = callbackRegistry.onPositionsEvent(positions -> {
+				connectionReadyLatch.countDown();
+			});
+			Closeable walletsInitCallback = callbackRegistry.onWalletsEvent(wallets -> {
+				connectionReadyLatch.countDown();
+			});
+			Closeable orderInitCallback = callbackRegistry.onExchangeOrdersEvent(exchangeOrders -> {
+				connectionReadyLatch.countDown();
+			});
 
 			final URI bitfinexURI = new URI(BITFINEX_URI);
-			websocketEndpoint = new WebsocketClientEndpoint(bitfinexURI);
-			websocketEndpoint.addConsumer(apiCallback);
+			websocketEndpoint = new WebsocketClientEndpoint(bitfinexURI, this::websocketCallback);
 			websocketEndpoint.connect();
 			updateConnectionHeartbeat();
 			
 			connectionFeatureManager.applyConnectionFeatures();
-			authenticate();
-			
-			heartbeatThread = new Thread(new HeartbeatThread(this, websocketEndpoint));
-			heartbeatThread.start();
+			if( configuration.isAuthenticationEnabled()) {
+				authenticateAndWait(connectionReadyLatch);
+			}
+
+			authSuccessEventCallback.close();
+			authFailedCallback.close();
+			positionInitCallback.close();
+			walletsInitCallback.close();
+			orderInitCallback.close();
+
+			if (configuration.isHeartbeatThreadActive()) {
+				heartbeatThread = new Thread(new HeartbeatThread(this, websocketEndpoint));
+				heartbeatThread.start();
+			}
 		} catch (Exception e) {
 			throw new APIException(e);
 		}
@@ -444,15 +380,15 @@ public class BitfinexApiBroker implements Closeable {
 	/**
 	 * Execute the authentication and wait until the socket is ready
 	 * @throws InterruptedException
-	 * @throws APIException 
+	 * @throws APIException
 	 */
-	private void authenticate() throws InterruptedException, APIException {
-        if (!canAuthenticate() || authenticated) {
-            return;
-        }
-		sendCommand(new AuthCommand(authNonceProducer));
+	private void authenticateAndWait(CountDownLatch latch) throws InterruptedException, APIException {
+		if (authenticated) {
+			return;
+		}
+		sendCommand(new AuthCommand(configuration.getAuthNonceProducer()));
 		logger.debug("Waiting for connection ready events");
-		connectionReadyLatch.await(10, TimeUnit.SECONDS);
+		latch.await(10, TimeUnit.SECONDS);
 
 		if (!authenticated) {
 			throw new APIException("Unable to perform authentication, capabilities are: " + capabilities);
@@ -460,31 +396,18 @@ public class BitfinexApiBroker implements Closeable {
 	}
 
 	/**
-	 * Is the connection to be authenticated
-	 * @return
-	 */
-	private boolean canAuthenticate() {
-		return apiKey != null && apiSecret != null;
-	}
-
-	/**
 	 * Disconnect the websocket
 	 */
 	@Override
 	public void close() {
-		if(heartbeatThread != null) {
+		if (heartbeatThread != null) {
 			heartbeatThread.interrupt();
 			heartbeatThread = null;
 		}
-		
-		if(websocketEndpoint != null) {
-			websocketEndpoint.removeConsumer(apiCallback);
+
+		if (websocketEndpoint != null) {
 			websocketEndpoint.close();
 			websocketEndpoint = null;
-		}
-		
-		if(executorService != null) {
-			executorService.shutdown();
 		}
 	}
 
@@ -543,7 +466,7 @@ public class BitfinexApiBroker implements Closeable {
 	 * Update the connection heartbeat
 	 */
 	public void updateConnectionHeartbeat() {
-		lastHeatbeat.set(System.currentTimeMillis());
+		lastHeartbeat.set(System.currentTimeMillis());
 	}
 
 	/**
@@ -653,29 +576,23 @@ public class BitfinexApiBroker implements Closeable {
 		
 		if(channelSymbol instanceof BitfinexCandlestickSymbol) {
 			final CandlestickHandler handler = new CandlestickHandler();
-			handler.onCandlesticksEvent(quoteManager::handleCandlestickCollection);
+			handler.onCandlesticksEvent(callbackRegistry::acceptCandlesticksEvent);
 			handler.handleChannelData(channelSymbol, jsonArray);
 		} else if(channelSymbol instanceof RawOrderbookConfiguration) {
 			final RawOrderbookHandler handler = new RawOrderbookHandler();
-			handler.onOrderbookEvent((sym, entries) -> {
-				entries.forEach(e -> rawOrderbookManager.handleNewOrderbookEntry(sym, e));
-			});
+			handler.onOrderbookEvent(callbackRegistry::acceptRawOrderbookEvent);
 			handler.handleChannelData(channelSymbol, jsonArray);
 		} else if(channelSymbol instanceof OrderbookConfiguration) {
 			final OrderbookHandler handler = new OrderbookHandler();
-			handler.onOrderbookEvent((sym,entries) -> {
-				entries.forEach(e -> orderbookManager.handleNewOrderbookEntry(sym, e));
-			});
+			handler.onOrderbookEvent(callbackRegistry::acceptOrderbookEvent);
 			handler.handleChannelData(channelSymbol, jsonArray);
 		} else if(channelSymbol instanceof BitfinexTickerSymbol) {
 			final TickHandler handler = new TickHandler();
-			handler.onTickEvent(quoteManager::handleNewTick);
+			handler.onTickEvent(callbackRegistry::acceptTickEvent);
 			handler.handleChannelData(channelSymbol, jsonArray);
 		} else if(channelSymbol instanceof BitfinexExecutedTradeSymbol) {
 			final ExecutedTradeHandler handler = new ExecutedTradeHandler();
-			handler.onExecutedTradeEvent((sym, trades) -> {
-				trades.forEach(t -> quoteManager.handleExecutedTradeEntry(sym, t));
-			});
+			handler.onExecutedTradeEvent(callbackRegistry::acceptExecutedTradeEvent);
 			handler.handleChannelData(channelSymbol, jsonArray);
 		} else {
 			logger.error("Unknown stream type: {}", channelSymbol);
@@ -732,6 +649,8 @@ public class BitfinexApiBroker implements Closeable {
 	public synchronized boolean reconnect() {
 		try {
 			logger.info("Performing reconnect");
+			websocketEndpoint.close();
+
 			capabilities = ConnectionCapabilities.NO_CAPABILITIES;
 			authenticated = false;
 			sequenceNumberAuditor.reset();
@@ -741,17 +660,43 @@ public class BitfinexApiBroker implements Closeable {
 			quoteManager.invalidateTickerHeartbeat();
 			orderManager.clear();
 			positionManager.clear();
-			
-			websocketEndpoint.close();
 
-			connectionReadyLatch = new CountDownLatch(CONNECTION_READY_EVENTS);
-			ordersUpdated = false;
-			walletsUpdated = false;
-			positionsUpdated = false;
+			CountDownLatch connectionReadyLatch = new CountDownLatch(4);
+
+			Closeable authSuccessEventCallback = callbackRegistry.onAuthenticationSuccessEvent(c -> {
+				capabilities = c;
+				authenticated = true;
+				connectionReadyLatch.countDown();
+			});
+			Closeable authFailedCallback = callbackRegistry.onAuthenticationFailedEvent(c -> {
+				capabilities = c;
+				authenticated = false;
+				while (connectionReadyLatch.getCount() != 0) {
+					connectionReadyLatch.countDown();
+				}
+			});
+			Closeable positionInitCallback = callbackRegistry.onPositionsEvent(positions -> {
+				connectionReadyLatch.countDown();
+			});
+			Closeable walletsInitCallback = callbackRegistry.onWalletsEvent(wallets -> {
+				connectionReadyLatch.countDown();
+			});
+			Closeable orderInitCallback = callbackRegistry.onExchangeOrdersEvent(exchangeOrders -> {
+				connectionReadyLatch.countDown();
+			});
+
 			websocketEndpoint.connect();
 			
 			connectionFeatureManager.applyConnectionFeatures();
-			authenticate();
+			if( configuration.isAuthenticationEnabled()) {
+				authenticateAndWait(connectionReadyLatch);
+			}
+			authSuccessEventCallback.close();
+			authFailedCallback.close();
+			positionInitCallback.close();
+			walletsInitCallback.close();
+			orderInitCallback.close();
+
 			resubscribeChannels();
 
 			updateConnectionHeartbeat();
@@ -883,24 +828,8 @@ public class BitfinexApiBroker implements Closeable {
 	 * Get the last heartbeat value
 	 * @return
 	 */
-	public AtomicLong getLastHeatbeat() {
-		return lastHeatbeat;
-	}
-	
-	/**
-	 * Get the API key
-	 * @return
-	 */
-	public String getApiKey() {
-		return apiKey;
-	}
-	
-	/**
-	 * Get the API secret
-	 * @return
-	 */
-	public String getApiSecret() {
-		return apiSecret;
+	public AtomicLong getLastHeartbeat() {
+		return lastHeartbeat;
 	}
 	
 	/**
@@ -998,20 +927,8 @@ public class BitfinexApiBroker implements Closeable {
 	public Map<Integer, BitfinexStreamSymbol> getChannelIdSymbolMap() {
 		return channelIdSymbolMap;
 	}
-	
-	/**
-	 * Is the dead man feature enabled
-	 * @return
-	 */
-	public boolean isDeadManFeatureEnabled() {
-		return deadManSwitch;
-	}
 
-	/**
-	 * Sets default auth nonce producer
-	 * @param authNonceProducer 	- default nonce producer used for authentication
-	 */
-	public void setDefaultAuthNonceProducer(final Supplier<String> authNonceProducer) {
-		this.authNonceProducer = Objects.requireNonNull(authNonceProducer);
+	public BitfinexApiBrokerConfig getConfiguration() {
+		return configuration;
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBrokerConfig.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBrokerConfig.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ *
+ *    Copyright (C) 2015-2018 Jan Kristof Nidzwetzki
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *******************************************************************************/
+package com.github.jnidzwetzki.bitfinex.v2;
+
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.github.jnidzwetzki.bitfinex.v2.commands.AuthCommand;
+
+public class BitfinexApiBrokerConfig {
+
+    private String apiKey;
+    private String apiSecret;
+    private boolean authenticationEnabled = false;
+    private boolean heartbeatThreadActive = true;
+    private boolean deadmanSwitchActive = false;
+    private boolean managersActive = true;
+    private Supplier<String> authNonceProducer = AuthCommand.AUTH_NONCE_PRODUCER_TIMESTAMP;
+    private ExecutorService executorService = MoreExecutors.newDirectExecutorService();
+
+    public BitfinexApiBrokerConfig() {
+
+    }
+
+    public BitfinexApiBrokerConfig(BitfinexApiBrokerConfig copy) {
+        this.apiKey = copy.apiKey;
+        this.apiSecret = copy.apiSecret;
+        this.authenticationEnabled = copy.authenticationEnabled;
+        this.heartbeatThreadActive = copy.heartbeatThreadActive;
+        this.deadmanSwitchActive = copy.deadmanSwitchActive;
+        this.managersActive = copy.managersActive;
+        this.authNonceProducer = copy.authNonceProducer;
+        this.executorService = copy.executorService;
+    }
+
+    public void setApiCredentials(String apiKey, String apiSecret) {
+        this.apiKey = apiKey;
+        this.apiSecret = apiSecret;
+        this.authenticationEnabled = true;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getApiSecret() {
+        return apiSecret;
+    }
+
+    public boolean isAuthenticationEnabled() {
+        return authenticationEnabled;
+    }
+
+    public void setAuthenticationEnabled(boolean authenticationEnabled) {
+        this.authenticationEnabled = authenticationEnabled;
+    }
+
+    public boolean isHeartbeatThreadActive() {
+        return heartbeatThreadActive;
+    }
+
+    public void setHeartbeatThreadActive(boolean heartbeatThreadActive) {
+        this.heartbeatThreadActive = heartbeatThreadActive;
+    }
+
+    public boolean isDeadmanSwitchActive() {
+        return deadmanSwitchActive;
+    }
+
+    public void setDeadmanSwitchActive(boolean deadmanSwitchActive) {
+        this.deadmanSwitchActive = deadmanSwitchActive;
+    }
+
+    public boolean isManagersActive() {
+        return managersActive;
+    }
+
+    public void setManagersActive(boolean managersActive) {
+        this.managersActive = managersActive;
+    }
+
+    public Supplier<String> getAuthNonceProducer() {
+        return authNonceProducer;
+    }
+
+    public void setAuthNonceProducer(Supplier<String> authNonceProducer) {
+        this.authNonceProducer = authNonceProducer;
+    }
+
+    public ExecutorService getExecutorService() {
+        return executorService;
+    }
+
+    public void setExecutorService(ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiCallbackRegistry.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiCallbackRegistry.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ *
+ *    Copyright (C) 2015-2018 Jan Kristof Nidzwetzki
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *******************************************************************************/
+package com.github.jnidzwetzki.bitfinex.v2;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandle;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexTick;
+import com.github.jnidzwetzki.bitfinex.v2.entity.ConnectionCapabilities;
+import com.github.jnidzwetzki.bitfinex.v2.entity.ExchangeOrder;
+import com.github.jnidzwetzki.bitfinex.v2.entity.ExecutedTrade;
+import com.github.jnidzwetzki.bitfinex.v2.entity.OrderbookConfiguration;
+import com.github.jnidzwetzki.bitfinex.v2.entity.OrderbookEntry;
+import com.github.jnidzwetzki.bitfinex.v2.entity.Position;
+import com.github.jnidzwetzki.bitfinex.v2.entity.RawOrderbookConfiguration;
+import com.github.jnidzwetzki.bitfinex.v2.entity.RawOrderbookEntry;
+import com.github.jnidzwetzki.bitfinex.v2.entity.Trade;
+import com.github.jnidzwetzki.bitfinex.v2.entity.Wallet;
+import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexCandlestickSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexExecutedTradeSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexTickerSymbol;
+
+public class BitfinexApiCallbackRegistry {
+
+    private final Queue<Consumer<ExchangeOrder>> exchangeOrderConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<Consumer<Collection<ExchangeOrder>>> exchangeOrdersConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<Consumer<Collection<Position>>> positionConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<Consumer<Trade>> tradeConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<Consumer<Collection<Wallet>>> walletConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<BiConsumer<BitfinexCandlestickSymbol, Collection<BitfinexCandle>>> candlesConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<BiConsumer<BitfinexExecutedTradeSymbol, Collection<ExecutedTrade>>> executedTradesConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<BiConsumer<OrderbookConfiguration, Collection<OrderbookEntry>>> orderbookEntryConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<BiConsumer<RawOrderbookConfiguration, Collection<RawOrderbookEntry>>> rawOrderbookEntryConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<BiConsumer<BitfinexTickerSymbol, BitfinexTick>> tickConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<Consumer<ConnectionCapabilities>> authSuccessConsumers = new ConcurrentLinkedQueue<>();
+    private final Queue<Consumer<ConnectionCapabilities>> authFailedConsumers = new ConcurrentLinkedQueue<>();
+
+    public Closeable onExchangeOrderNotification(Consumer<ExchangeOrder> consumer) {
+        exchangeOrderConsumers.offer(consumer);
+        return () -> exchangeOrderConsumers.remove(consumer);
+    }
+
+    public void acceptExchangeOrderNotification(ExchangeOrder event) {
+        exchangeOrderConsumers.forEach(consumer -> consumer.accept(event));
+    }
+
+    public Closeable onExchangeOrdersEvent(Consumer<Collection<ExchangeOrder>> consumer) {
+        exchangeOrdersConsumers.offer(consumer);
+        return () -> exchangeOrdersConsumers.remove(consumer);
+    }
+
+    public void acceptExchangeOrdersEvent(Collection<ExchangeOrder> event) {
+        exchangeOrdersConsumers.forEach(consumer -> consumer.accept(event));
+    }
+
+    public Closeable onPositionsEvent(Consumer<Collection<Position>> consumer) {
+        positionConsumers.offer(consumer);
+        return () -> positionConsumers.remove(consumer);
+    }
+
+    public void acceptPositionsEvent(Collection<Position> event) {
+        positionConsumers.forEach(consumer -> consumer.accept(event));
+    }
+
+    public Closeable onTradeEvent(Consumer<Trade> consumer) {
+        tradeConsumers.offer(consumer);
+        return () -> tradeConsumers.remove(consumer);
+    }
+
+    public void acceptTradeEvent(Trade event) {
+        tradeConsumers.forEach(consumer -> consumer.accept(event));
+    }
+
+    public Closeable onWalletsEvent(Consumer<Collection<Wallet>> consumer) {
+        walletConsumers.offer(consumer);
+        return () -> walletConsumers.remove(consumer);
+    }
+
+    public void acceptWalletsEvent(Collection<Wallet> event) {
+        walletConsumers.forEach(consumer -> consumer.accept(event));
+    }
+
+    public Closeable onCandlesticksEvent(BiConsumer<BitfinexCandlestickSymbol, Collection<BitfinexCandle>> consumer) {
+        candlesConsumers.offer(consumer);
+        return () -> candlesConsumers.remove(consumer);
+    }
+
+    public void acceptCandlesticksEvent(BitfinexCandlestickSymbol symbol, Collection<BitfinexCandle> entries) {
+        candlesConsumers.forEach(consumer -> consumer.accept(symbol, entries));
+    }
+
+    public Closeable onExecutedTradeEvent(BiConsumer<BitfinexExecutedTradeSymbol, Collection<ExecutedTrade>> consumer) {
+        executedTradesConsumers.offer(consumer);
+        return () -> executedTradesConsumers.remove(consumer);
+    }
+
+    public void acceptExecutedTradeEvent(BitfinexExecutedTradeSymbol symbol, Collection<ExecutedTrade> entries) {
+        executedTradesConsumers.forEach(consumer -> consumer.accept(symbol, entries));
+    }
+
+    public Closeable onOrderbookEvent(BiConsumer<OrderbookConfiguration, Collection<OrderbookEntry>> consumer) {
+        orderbookEntryConsumers.offer(consumer);
+        return () -> orderbookEntryConsumers.remove(consumer);
+    }
+
+    public void acceptOrderbookEvent(OrderbookConfiguration symbol, Collection<OrderbookEntry> entries) {
+        orderbookEntryConsumers.forEach(consumer -> consumer.accept(symbol, entries));
+    }
+
+    public Closeable onRawOrderbookEvent(BiConsumer<RawOrderbookConfiguration, Collection<RawOrderbookEntry>> consumer) {
+        rawOrderbookEntryConsumers.offer(consumer);
+        return () -> rawOrderbookEntryConsumers.remove(consumer);
+    }
+
+    public void acceptRawOrderbookEvent(RawOrderbookConfiguration symbol, Collection<RawOrderbookEntry> entries) {
+        rawOrderbookEntryConsumers.forEach(consumer -> consumer.accept(symbol, entries));
+    }
+
+    public Closeable onTickEvent(BiConsumer<BitfinexTickerSymbol, BitfinexTick> consumer) {
+        tickConsumers.offer(consumer);
+        return () -> tickConsumers.remove(consumer);
+    }
+
+    public void acceptTickEvent(BitfinexTickerSymbol symbol, BitfinexTick tick) {
+        tickConsumers.forEach(consumer -> consumer.accept(symbol, tick));
+    }
+
+    public Closeable onAuthenticationSuccessEvent(Consumer<ConnectionCapabilities> consumer) {
+        authSuccessConsumers.offer(consumer);
+        return () -> authSuccessConsumers.remove(consumer);
+    }
+
+    public void acceptAuthenticationSuccessEvent(ConnectionCapabilities event) {
+        authSuccessConsumers.forEach(consumer -> consumer.accept(event));
+    }
+
+    public Closeable onAuthenticationFailedEvent(Consumer<ConnectionCapabilities> consumer) {
+        authFailedConsumers.offer(consumer);
+        return () -> authFailedConsumers.remove(consumer);
+    }
+
+    public void acceptAuthenticationFailedEvent(ConnectionCapabilities event) {
+        authFailedConsumers.forEach(consumer -> consumer.accept(event));
+    }
+
+}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/HeartbeatThread.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/HeartbeatThread.java
@@ -170,7 +170,7 @@ public class HeartbeatThread extends ExceptionSafeRunnable {
 	 * Send a heartbeat package on the connection
 	 */
 	private void sendHeartbeatIfNeeded() {
-		final long nextHeartbeat = bitfinexApiBroker.getLastHeatbeat().get() + HEARTBEAT;
+		final long nextHeartbeat = bitfinexApiBroker.getLastHeartbeat().get() + HEARTBEAT;
 
 		if(nextHeartbeat < System.currentTimeMillis()) {
 			logger.debug("Send heartbeat");
@@ -183,7 +183,7 @@ public class HeartbeatThread extends ExceptionSafeRunnable {
 	 * @return
 	 */
 	private boolean checkConnectionTimeout() {
-		final long heartbeatTimeout = bitfinexApiBroker.getLastHeatbeat().get() + CONNECTION_TIMEOUT;
+		final long heartbeatTimeout = bitfinexApiBroker.getLastHeartbeat().get() + CONNECTION_TIMEOUT;
 
 		if(heartbeatTimeout < System.currentTimeMillis()) {
 			logger.error("Heartbeat timeout reconnecting");

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/AuthCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/AuthCommand.java
@@ -52,9 +52,9 @@ public class AuthCommand extends AbstractAPICommand {
 	@Override
 	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
 		try {
-			final String APIKey = bitfinexApiBroker.getApiKey();
-			final String APISecret = bitfinexApiBroker.getApiSecret();
-			final boolean deadManSwitch = bitfinexApiBroker.isDeadManFeatureEnabled();
+			final String APIKey = bitfinexApiBroker.getConfiguration().getApiKey();
+			final String APISecret = bitfinexApiBroker.getConfiguration().getApiSecret();
+			final boolean deadManSwitch = bitfinexApiBroker.getConfiguration().isDeadmanSwitchActive();
 			
 			final String authNonce = authNonceSupplier.get();
 			final String authPayload = "AUTH" + authNonce;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeOrderbookCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
@@ -34,9 +35,13 @@ public class OrderbookManager extends AbstractManager {
 	 */
 	private final BiConsumerCallbackManager<OrderbookConfiguration, OrderbookEntry> channelCallbacks;
 
-	public OrderbookManager(final BitfinexApiBroker bitfinexApiBroker, ExecutorService executorService) {
+	public OrderbookManager(final BitfinexApiBroker bitfinexApiBroker, ExecutorService executorService,
+							BitfinexApiCallbackRegistry callbackRegistry) {
 		super(bitfinexApiBroker, executorService);
 		this.channelCallbacks = new BiConsumerCallbackManager<>(executorService, bitfinexApiBroker);
+		callbackRegistry.onOrderbookEvent((sym,entries) -> {
+			entries.forEach(e -> handleNewOrderbookEntry(sym, e));
+		});
 	}
 	
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/PositionManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/PositionManager.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.entity.Position;
 
 public class PositionManager extends SimpleCallbackManager<Position> {
@@ -31,9 +32,10 @@ public class PositionManager extends SimpleCallbackManager<Position> {
 	 */
 	private final List<Position> positions;
 
-	public PositionManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService) {
+	public PositionManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService, BitfinexApiCallbackRegistry callbackRegistry) {
 		super(executorService, bitfinexApiBroker);
 		this.positions = new ArrayList<>();
+		callbackRegistry.onPositionsEvent(positions -> positions.forEach(this::updatePosition));
 	}
 
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeRawOrderbookCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
@@ -34,9 +35,13 @@ public class RawOrderbookManager extends AbstractManager {
 	 */
 	private final BiConsumerCallbackManager<RawOrderbookConfiguration, RawOrderbookEntry> channelCallbacks;
 
-	public RawOrderbookManager(final BitfinexApiBroker bitfinexApiBroker, ExecutorService executorService) {
+	public RawOrderbookManager(final BitfinexApiBroker bitfinexApiBroker, ExecutorService executorService,
+							   BitfinexApiCallbackRegistry callbackRegistry) {
 		super(bitfinexApiBroker, executorService);
 		this.channelCallbacks = new BiConsumerCallbackManager<>(executorService, bitfinexApiBroker);
+		callbackRegistry.onRawOrderbookEvent((sym, entries) -> {
+			entries.forEach(e -> handleNewOrderbookEntry(sym, e));
+		});
 	}
 	
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/TradeManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/TradeManager.java
@@ -18,22 +18,24 @@
 package com.github.jnidzwetzki.bitfinex.v2.manager;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.entity.Trade;
 
 import java.util.concurrent.ExecutorService;
 
 public class TradeManager extends SimpleCallbackManager<Trade> {
 
-	public TradeManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService) {
+	public TradeManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService, BitfinexApiCallbackRegistry callbackRegistry) {
 		super(executorService, bitfinexApiBroker);
+		callbackRegistry.onTradeEvent(this::updateTrade);
 	}
 	
 	/**
 	 * Update a exchange order
-	 * @param exchangeOrder
+	 * @param trade
 	 */
 	public void updateTrade(final Trade trade) {
-		trade.setApikey(bitfinexApiBroker.getApiKey());
+		trade.setApikey(bitfinexApiBroker.getConfiguration().getApiKey());
 		notifyCallbacks(trade);
 	}
 	

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/WalletManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/WalletManager.java
@@ -1,19 +1,19 @@
 /*******************************************************************************
  *
  *    Copyright (C) 2015-2018 Jan Kristof Nidzwetzki
- *  
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- *  
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License. 
- *    
+ *
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.manager;
 
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.commands.CalculateCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.Wallet;
@@ -29,37 +30,48 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
 public class WalletManager extends AbstractManager {
-	
+
 	/**
 	 * Wallets
-	 * 
+	 *
 	 *  Currency, Wallet-Type, Wallet
 	 */
 	private final Table<String, String, Wallet> walletTable;
-	
-	public WalletManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService) {
+
+	public WalletManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService, BitfinexApiCallbackRegistry callbackRegistry) {
 		super(bitfinexApiBroker, executorService);
 		this.walletTable = HashBasedTable.create();
+		callbackRegistry.onWalletsEvent(wallets -> wallets.forEach(wallet -> {
+            try {
+                Table<String, String, Wallet> walletTable = getWalletTable();
+                synchronized (walletTable) {
+                    walletTable.put(wallet.getWalletType(), wallet.getCurreny(), wallet);
+                    walletTable.notifyAll();
+                }
+            } catch (APIException e) {
+                e.printStackTrace();
+            }
+        }));
 	}
-	
+
 	/**
 	 * Get all wallets
-	 * @return 
-	 * @throws APIException 
+	 * @return
+	 * @throws APIException
 	 */
-	public Collection<Wallet> getWallets() throws APIException {		
-		
+	public Collection<Wallet> getWallets() throws APIException {
+
 		throwExceptionIfUnauthenticated();
-		
+
 		synchronized (walletTable) {
 			return Collections.unmodifiableCollection(walletTable.values());
 		}
 	}
-	
+
 	/**
 	 * Get all wallets
-	 * @return 
-	 * @throws APIException 
+	 * @return
+	 * @throws APIException
 	 */
 	public Table<String, String, Wallet> getWalletTable() throws APIException {
 		return walletTable;
@@ -74,29 +86,29 @@ public class WalletManager extends AbstractManager {
 			throw new APIException("Unable to perform operation on an unauthenticated connection");
 		}
 	}
-	
+
 	/**
 	 * Calculate the wallet margin balance for the given currency (e.g., BTC)
-	 * 
+	 *
 	 * @param symbol
-	 * @throws APIException 
+	 * @throws APIException
 	 */
 	public void calculateWalletMarginBalance(final String symbol) throws APIException {
 		throwExceptionIfUnauthenticated();
 
 		bitfinexApiBroker.sendCommand(new CalculateCommand("wallet_margin_" + symbol));
 	}
-	
+
 	/**
 	 * Calculate the wallet funding balance for the given currency (e.g., BTC)
-	 * 
+	 *
 	 * @param symbol
-	 * @throws APIException 
+	 * @throws APIException
 	 */
 	public void calculateWalletFundingBalance(final String symbol) throws APIException {
 		throwExceptionIfUnauthenticated();
 
 		bitfinexApiBroker.sendCommand(new CalculateCommand("wallet_funding_" + symbol));
 	}
-	
+
 }

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexOrderBuilder;
 import com.github.jnidzwetzki.bitfinex.v2.commands.AbstractAPICommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.AuthCommand;
@@ -114,8 +115,11 @@ public class CommandsTest {
 	 */
 	private BitfinexApiBroker buildMockedBitfinexConnection() {
 		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-		Mockito.when(bitfinexApiBroker.getApiKey()).thenReturn("abc");
-		Mockito.when(bitfinexApiBroker.getApiSecret()).thenReturn("123");
+		final BitfinexApiBrokerConfig config = Mockito.mock(BitfinexApiBrokerConfig.class);
+
+		Mockito.when(bitfinexApiBroker.getConfiguration()).thenReturn(config);
+		Mockito.when(bitfinexApiBroker.getConfiguration().getApiKey()).thenReturn("abc");
+		Mockito.when(bitfinexApiBroker.getConfiguration().getApiSecret()).thenReturn("123");
 		return bitfinexApiBroker;
 	}
 }

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
 import com.github.jnidzwetzki.bitfinex.v2.SequenceNumberAuditor;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
@@ -58,7 +59,7 @@ public class IntegrationTest {
 	@Test
 	public void testWalletsOnUnauthClient() throws APIException {
 
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 		try {
 			bitfinexClient.connect();
@@ -88,7 +89,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=10000)
 	public void testOrderbookStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 		// Await at least 10 callbacks
 		final CountDownLatch latch = new CountDownLatch(10);
@@ -130,7 +131,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=10000)
 	public void testRawOrderbookStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 		// Await at least 20 callbacks
 		final CountDownLatch latch = new CountDownLatch(20);
@@ -172,7 +173,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=10000)
 	public void testCandleStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 		try {
 			bitfinexClient.connect();
@@ -215,7 +216,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=60000)
 	public void testExecutedTradesStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 		// Await at least 2 callbacks
 		final CountDownLatch latch = new CountDownLatch(2);
@@ -252,7 +253,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=60000)
 	public void testUnsubscrribeAllChannels() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 
 		try {
@@ -299,7 +300,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=60000)
 	public void testTickerStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 		// Await at least 2 callbacks
 		final CountDownLatch latch = new CountDownLatch(2);
@@ -337,14 +338,16 @@ public class IntegrationTest {
 	 * Test auth failed
 	 * @throws APIException
 	 */
-	@Test(expected=APIException.class, timeout=10000)
+	@Test(expected=APIException.class, timeout=900000)
 	public void testAuthFailed() throws APIException {
 		final String KEY = "key";
 		final String SECRET = "secret";
 
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(KEY, SECRET);
-		Assert.assertEquals(KEY, bitfinexClient.getApiKey());
-		Assert.assertEquals(SECRET, bitfinexClient.getApiSecret());
+		BitfinexApiBrokerConfig config = new BitfinexApiBrokerConfig();
+		config.setApiCredentials(KEY, SECRET);
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(config);
+		Assert.assertEquals(KEY, bitfinexClient.getConfiguration().getApiKey());
+		Assert.assertEquals(SECRET, bitfinexClient.getConfiguration().getApiSecret());
 
 		Assert.assertFalse(bitfinexClient.isAuthenticated());
 
@@ -362,7 +365,7 @@ public class IntegrationTest {
 	 */
 	@Test
 	public void testReconnect() throws APIException, InterruptedException {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 		bitfinexClient.connect();
 
 		final BitfinexTickerSymbol symbol = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("BTC","USD"));
@@ -397,7 +400,7 @@ public class IntegrationTest {
 	 */
 	@Test
 	public void testSequencing() throws APIException, InterruptedException {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 		bitfinexClient.connect();
 
 		final SequenceNumberAuditor sequenceNumberAuditor = bitfinexClient.getSequenceNumberAuditor();
@@ -448,7 +451,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=10000)
 	public void testErrorCallback() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 
 		// Await at least 5 callbacks
 		final CountDownLatch latch = new CountDownLatch(5);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/PositionTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/PositionTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.api.PositionHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.Position;
@@ -112,7 +113,7 @@ public class PositionTest {
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
 		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
 		
-		final PositionManager positionManager = new PositionManager(bitfinexApiBroker, executorService);
+		final PositionManager positionManager = new PositionManager(bitfinexApiBroker, executorService, new BitfinexApiCallbackRegistry());
 		Mockito.when(bitfinexApiBroker.getPositionManager()).thenReturn(positionManager);
 		
 		return bitfinexApiBroker;

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/CandlestickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/CandlestickHandlerTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.CandlestickHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
@@ -54,10 +55,11 @@ public class CandlestickHandlerTest {
 		
 		final BitfinexCandlestickSymbol symbol 
 			= new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), Timeframe.MINUTES_1);
+		final BitfinexApiCallbackRegistry callbackRegistry = new BitfinexApiCallbackRegistry();
 		
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
 		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-		final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService);
+		final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService, callbackRegistry);
 		Mockito.when(bitfinexApiBroker.getQuoteManager()).thenReturn(tickerManager);
 
 		final AtomicInteger counter = new AtomicInteger(0);
@@ -92,10 +94,11 @@ public class CandlestickHandlerTest {
 		
 		final BitfinexCandlestickSymbol symbol 
 			= new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), Timeframe.MINUTES_1);
-			
+		final BitfinexApiCallbackRegistry callbackRegistry = new BitfinexApiCallbackRegistry();
+
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
 		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-		final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService);
+		final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService, callbackRegistry);
 		Mockito.when(bitfinexApiBroker.getQuoteManager()).thenReturn(tickerManager);
 
 		final AtomicInteger counter = new AtomicInteger(0);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/ExecutedTradesHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/ExecutedTradesHandlerTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.ExecutedTradeHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
@@ -56,7 +57,7 @@ public class ExecutedTradesHandlerTest {
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
         final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-        final QuoteManager quoteManager = new QuoteManager(bitfinexApiBroker, executorService);
+        final QuoteManager quoteManager = new QuoteManager(bitfinexApiBroker, executorService, new BitfinexApiCallbackRegistry());
         Mockito.when(bitfinexApiBroker.getQuoteManager()).thenReturn(quoteManager);
 
         quoteManager.registerExecutedTradeCallback(symbol, (s, c) -> {
@@ -88,7 +89,7 @@ public class ExecutedTradesHandlerTest {
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
         final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-        final QuoteManager quoteManager = new QuoteManager(bitfinexApiBroker, executorService);
+        final QuoteManager quoteManager = new QuoteManager(bitfinexApiBroker, executorService, new BitfinexApiCallbackRegistry());
         Mockito.when(bitfinexApiBroker.getQuoteManager()).thenReturn(quoteManager);
 
         quoteManager.registerExecutedTradeCallback(symbol, (s, c) -> {

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/TickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/TickHandlerTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.TickHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
@@ -56,7 +57,7 @@ public class TickHandlerTest {
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
         final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-        final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService);
+        final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService, new BitfinexApiCallbackRegistry());
         Mockito.when(bitfinexApiBroker.getQuoteManager()).thenReturn(tickerManager);
 
         tickerManager.registerTickCallback(symbol, (s, c) -> {

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TestHelper.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TestHelper.java
@@ -22,6 +22,8 @@ import java.util.concurrent.ExecutorService;
 import org.mockito.Mockito;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.entity.ConnectionCapabilities;
 import com.github.jnidzwetzki.bitfinex.v2.manager.OrderManager;
 import com.github.jnidzwetzki.bitfinex.v2.manager.TradeManager;
@@ -39,16 +41,20 @@ public class TestHelper {
 	 * @return
 	 */
 	public static BitfinexApiBroker buildMockedBitfinexConnection() {
-		
+
 		final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
 		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-		
-		Mockito.when(bitfinexApiBroker.getApiKey()).thenReturn(API_KEY);
+		final BitfinexApiBrokerConfig config = Mockito.mock(BitfinexApiBrokerConfig.class);
+		final BitfinexApiCallbackRegistry callbackRegistry = new BitfinexApiCallbackRegistry();
+
+
+		Mockito.when(bitfinexApiBroker.getConfiguration()).thenReturn(config);
+		Mockito.when(config.getApiKey()).thenReturn(API_KEY);
 		Mockito.when(bitfinexApiBroker.isAuthenticated()).thenReturn(true);
 		Mockito.when(bitfinexApiBroker.getCapabilities()).thenReturn(ConnectionCapabilities.ALL_CAPABILITIES);
 
-		final OrderManager orderManager = new OrderManager(bitfinexApiBroker, executorService);
-		final TradeManager tradeManager = new TradeManager(bitfinexApiBroker, executorService);
+		final OrderManager orderManager = new OrderManager(bitfinexApiBroker, executorService, callbackRegistry);
+		final TradeManager tradeManager = new TradeManager(bitfinexApiBroker, executorService, callbackRegistry);
 		Mockito.when(bitfinexApiBroker.getOrderManager()).thenReturn(orderManager);
 		Mockito.when(bitfinexApiBroker.getTradeManager()).thenReturn(tradeManager);
 

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TradeManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TradeManagerTest.java
@@ -26,6 +26,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.api.TradeHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
@@ -122,12 +124,14 @@ public class TradeManagerTest {
 
         final ExecutorService executorService = Executors.newFixedThreadPool(10);
         final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+        final BitfinexApiBrokerConfig config = Mockito.mock(BitfinexApiBrokerConfig.class);
 
-        Mockito.when(bitfinexApiBroker.getApiKey()).thenReturn(API_KEY);
+        Mockito.when(bitfinexApiBroker.getConfiguration()).thenReturn(config);
+        Mockito.when(config.getApiKey()).thenReturn(API_KEY);
         Mockito.when(bitfinexApiBroker.isAuthenticated()).thenReturn(true);
         Mockito.when(bitfinexApiBroker.getCapabilities()).thenReturn(ConnectionCapabilities.ALL_CAPABILITIES);
 
-        final TradeManager tradeManager = new TradeManager(bitfinexApiBroker, executorService);
+        final TradeManager tradeManager = new TradeManager(bitfinexApiBroker, executorService, new BitfinexApiCallbackRegistry());
         Mockito.when(bitfinexApiBroker.getTradeManager()).thenReturn(tradeManager);
 
         return bitfinexApiBroker;


### PR DESCRIPTION
New callback layer introduced. After my recent PRs application was communicating between components as follow:

event handlers (many) <- register mess in ApiBrokker ->(many) managers

now, it'll work as follows, lot cleaner solution - 
event handlers (many) <- (1) CallbackRegistry (1) ->(many) managers

Finally achieved managers decoupling from BitfinexApiBroker and event handlers.

There is still space for improvements - CallbackRegistry should be exposed - I will address this and few others in future PRs

Please revert yr latest commit and merge against commit 41d674b