### PR TITLE
BitfinexApiBroker.channelIdSymbolMap improvements

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -833,6 +833,10 @@ public class BitfinexApiBroker implements Closeable {
 		return authenticated;
 	}
 
+	public ConnectionCapabilities getCapabilities() {
+		return capabilities;
+	}
+
 	public AtomicLong getLastHeartbeat() {
 		return lastHeartbeat;
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/UnsubscribeChannelCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/UnsubscribeChannelCommand.java
@@ -1,19 +1,19 @@
 /*******************************************************************************
  *
  *    Copyright (C) 2015-2018 Jan Kristof Nidzwetzki
- *  
+ *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
  *    You may obtain a copy of the License at
- *  
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *    Unless required by applicable law or agreed to in writing, software
  *    distributed under the License is distributed on an "AS IS" BASIS,
  *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *    See the License for the specific language governing permissions and
  *    limitations under the License. 
- *    
+ *
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.commands;
 
@@ -32,7 +32,9 @@ public class UnsubscribeChannelCommand extends AbstractAPICommand implements Bit
 	 * The channel to unsubscribe
 	 */
 	private final BitfinexStreamSymbol symbol;
-	private Function<BitfinexStreamSymbol, Integer> channelIdResolver;
+	private Function<BitfinexStreamSymbol, Integer> channelIdResolver = s -> {
+	    throw new IllegalStateException("Resolver is not set");
+    };
 
 	public UnsubscribeChannelCommand(final BitfinexStreamSymbol symbol) {
 		this.symbol = symbol;
@@ -43,7 +45,7 @@ public class UnsubscribeChannelCommand extends AbstractAPICommand implements Bit
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "unsubscribe");
 		subscribeJson.put("chanId", channelIdResolver.apply(symbol));
-		
+
 		return subscribeJson.toString();
 	}
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/UnsubscribeChannelCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/commands/UnsubscribeChannelCommand.java
@@ -17,28 +17,38 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.commands;
 
+import java.util.Objects;
+import java.util.function.Function;
+
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexStreamSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.util.BitfinexStreamSymbolToChannelIdResolverAware;
 
-public class UnsubscribeChannelCommand extends AbstractAPICommand {
+public class UnsubscribeChannelCommand extends AbstractAPICommand implements BitfinexStreamSymbolToChannelIdResolverAware {
 
 	/**
 	 * The channel to unsubscribe
 	 */
-	private final int channel;
+	private final BitfinexStreamSymbol symbol;
+	private Function<BitfinexStreamSymbol, Integer> channelIdResolver;
 
-	public UnsubscribeChannelCommand(final int channel) {
-		this.channel = channel;
+	public UnsubscribeChannelCommand(final BitfinexStreamSymbol symbol) {
+		this.symbol = symbol;
 	}
 
 	@Override
 	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "unsubscribe");
-		subscribeJson.put("chanId", channel);
+		subscribeJson.put("chanId", channelIdResolver.apply(symbol));
 		
 		return subscribeJson.toString();
 	}
 
+	@Override
+	public void setResolver(Function<BitfinexStreamSymbol, Integer> channelIdResolver) {
+		this.channelIdResolver = Objects.requireNonNull(channelIdResolver);
+	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
@@ -92,14 +92,7 @@ public class OrderbookManager extends AbstractManager {
 	 * @param pricePoints
 	 */
 	public void unsubscribeOrderbook(final OrderbookConfiguration orderbookConfiguration) {
-		
-		final int channel = bitfinexApiBroker.getChannelForSymbol(orderbookConfiguration);
-		
-		if(channel == -1) {
-			throw new IllegalArgumentException("Unknown symbol: " + orderbookConfiguration);
-		}
-		
-		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(channel);
+		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(orderbookConfiguration);
 		bitfinexApiBroker.sendCommand(command);
 		bitfinexApiBroker.removeChannelForSymbol(orderbookConfiguration);
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
@@ -46,8 +46,6 @@ public class OrderbookManager extends AbstractManager {
 	
 	/**
 	 * Register a new trading orderbook callback
-	 * @param symbol
-	 * @param callback
 	 * @throws APIException
 	 */
 	public void registerOrderbookCallback(final OrderbookConfiguration orderbookConfiguration, 
@@ -58,10 +56,6 @@ public class OrderbookManager extends AbstractManager {
 	
 	/**
 	 * Remove the a trading orderbook callback
-	 * @param symbol
-	 * @param callback
-	 * @return
-	 * @throws APIException
 	 */
 	public boolean removeOrderbookCallback(final OrderbookConfiguration orderbookConfiguration, 
 			final BiConsumer<OrderbookConfiguration, OrderbookEntry> callback) throws APIException {
@@ -71,10 +65,6 @@ public class OrderbookManager extends AbstractManager {
 	
 	/**
 	 * Subscribe a orderbook
-	 * @param currencyPair
-	 * @param orderBookPrecision
-	 * @param orderBookFrequency
-	 * @param pricePoints
 	 */
 	public void subscribeOrderbook(final OrderbookConfiguration orderbookConfiguration) {
 		
@@ -86,21 +76,14 @@ public class OrderbookManager extends AbstractManager {
 	
 	/**
 	 * Unsubscribe a orderbook
-	 * @param currencyPair
-	 * @param orderBookPrecision
-	 * @param orderBookFrequency
-	 * @param pricePoints
 	 */
 	public void unsubscribeOrderbook(final OrderbookConfiguration orderbookConfiguration) {
 		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(orderbookConfiguration);
 		bitfinexApiBroker.sendCommand(command);
-		bitfinexApiBroker.removeChannelForSymbol(orderbookConfiguration);
 	}
 	
 	/**
 	 * Handle a new orderbook entry
-	 * @param symbol
-	 * @param tick
 	 */
 	public void handleNewOrderbookEntry(final OrderbookConfiguration configuration, 
 			final OrderbookEntry entry) {

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
@@ -66,13 +66,6 @@ public class QuoteManager extends AbstractManager {
 	 */
 	private final BitfinexApiBroker bitfinexApiBroker;
 	
-	/**
-	 * The number of symbols that can be subscribed within one connection
-	 * @see https://www.bitfinex.com/posts/267
-	 */
-	public static int SYMBOL_QUOTA = 50;
-	
-
 	public QuoteManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService, BitfinexApiCallbackRegistry callbackRegistry) {
 		super(bitfinexApiBroker, executorService);
 		this.bitfinexApiBroker = bitfinexApiBroker;
@@ -169,22 +162,8 @@ public class QuoteManager extends AbstractManager {
 	 * @throws APIException 
 	 */
 	public void subscribeTicker(final BitfinexTickerSymbol tickerSymbol) throws APIException {
-		checkForQuota();
 		final SubscribeTickerCommand command = new SubscribeTickerCommand(tickerSymbol);
 		bitfinexApiBroker.sendCommand(command);
-	}
-
-	/**
-	 * A quota on the bitfinex side prevents that more than 50 symbols can 
-	 * be subscribed per connection
-	 * 
-	 * @throws APIException
-	 */
-	private void checkForQuota() throws APIException {
-		if(bitfinexApiBroker.getChannelIdSymbolMap().size() >= SYMBOL_QUOTA) {
-			throw new APIException("Unable to subscript more than " + SYMBOL_QUOTA 
-					+ " symbols per connection");
-		}
 	}
 
 	/**
@@ -195,7 +174,6 @@ public class QuoteManager extends AbstractManager {
 		lastTickerActivity.remove(tickerSymbol);
 		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(tickerSymbol);
 		bitfinexApiBroker.sendCommand(command);
-		bitfinexApiBroker.removeChannelForSymbol(tickerSymbol);
 	}
 
 	/**
@@ -250,7 +228,6 @@ public class QuoteManager extends AbstractManager {
 	 * @throws APIException 
 	 */
 	public void subscribeCandles(final BitfinexCandlestickSymbol symbol) throws APIException {
-		checkForQuota();
 		final SubscribeCandlesCommand command = new SubscribeCandlesCommand(symbol);
 		bitfinexApiBroker.sendCommand(command);
 	}
@@ -264,7 +241,6 @@ public class QuoteManager extends AbstractManager {
 		lastTickerActivity.remove(symbol);
 		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(symbol);
 		bitfinexApiBroker.sendCommand(command);
-		bitfinexApiBroker.removeChannelForSymbol(symbol);
 	}
 
 
@@ -318,7 +294,6 @@ public class QuoteManager extends AbstractManager {
 	public void unsubscribeExecutedTrades(final BitfinexExecutedTradeSymbol tradeSymbol) {
 		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(tradeSymbol);
 		bitfinexApiBroker.sendCommand(command);
-		bitfinexApiBroker.removeChannelForSymbol(tradeSymbol);
 	}
 
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
@@ -192,16 +192,8 @@ public class QuoteManager extends AbstractManager {
 	 * @param tickerSymbol
 	 */
 	public void unsubscribeTicker(final BitfinexTickerSymbol tickerSymbol) {
-
 		lastTickerActivity.remove(tickerSymbol);
-
-		final int channel = bitfinexApiBroker.getChannelForSymbol(tickerSymbol);
-
-		if(channel == -1) {
-			throw new IllegalArgumentException("Unknown symbol: " + tickerSymbol);
-		}
-
-		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(channel);
+		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(tickerSymbol);
 		bitfinexApiBroker.sendCommand(command);
 		bitfinexApiBroker.removeChannelForSymbol(tickerSymbol);
 	}
@@ -269,16 +261,8 @@ public class QuoteManager extends AbstractManager {
 	 * @param timeframe
 	 */
 	public void unsubscribeCandles(final BitfinexCandlestickSymbol symbol) {
-
 		lastTickerActivity.remove(symbol);
-
-		final int channel = bitfinexApiBroker.getChannelForSymbol(symbol);
-
-		if(channel == -1) {
-			throw new IllegalArgumentException("Unknown symbol: " + symbol);
-		}
-
-		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(channel);
+		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(symbol);
 		bitfinexApiBroker.sendCommand(command);
 		bitfinexApiBroker.removeChannelForSymbol(symbol);
 	}
@@ -332,14 +316,7 @@ public class QuoteManager extends AbstractManager {
 	 * @param pricePoints
 	 */
 	public void unsubscribeExecutedTrades(final BitfinexExecutedTradeSymbol tradeSymbol) {
-
-		final int channel = bitfinexApiBroker.getChannelForSymbol(tradeSymbol);
-
-		if(channel == -1) {
-			throw new IllegalArgumentException("Unknown symbol: " + tradeSymbol);
-		}
-
-		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(channel);
+		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(tradeSymbol);
 		bitfinexApiBroker.sendCommand(command);
 		bitfinexApiBroker.removeChannelForSymbol(tradeSymbol);
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
@@ -94,7 +94,6 @@ public class RawOrderbookManager extends AbstractManager {
 	public void unsubscribeOrderbook(final RawOrderbookConfiguration orderbookConfiguration) {
 		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(orderbookConfiguration);
 		bitfinexApiBroker.sendCommand(command);
-		bitfinexApiBroker.removeChannelForSymbol(orderbookConfiguration);
 	}
 	
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
@@ -92,14 +92,7 @@ public class RawOrderbookManager extends AbstractManager {
 	 * @param pricePoints
 	 */
 	public void unsubscribeOrderbook(final RawOrderbookConfiguration orderbookConfiguration) {
-		
-		final int channel = bitfinexApiBroker.getChannelForSymbol(orderbookConfiguration);
-		
-		if(channel == -1) {
-			throw new IllegalArgumentException("Unknown symbol: " + orderbookConfiguration);
-		}
-		
-		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(channel);
+		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(orderbookConfiguration);
 		bitfinexApiBroker.sendCommand(command);
 		bitfinexApiBroker.removeChannelForSymbol(orderbookConfiguration);
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/util/BitfinexStreamSymbolToChannelIdResolverAware.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/util/BitfinexStreamSymbolToChannelIdResolverAware.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ *
+ *    Copyright (C) 2015-2018 Jan Kristof Nidzwetzki
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *******************************************************************************/
+
+package com.github.jnidzwetzki.bitfinex.v2.util;
+
+import java.util.function.Function;
+
+import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexStreamSymbol;
+
+public interface BitfinexStreamSymbolToChannelIdResolverAware {
+
+    void setResolver(Function<BitfinexStreamSymbol, Integer> channelIdResolver);
+}

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
@@ -20,22 +20,23 @@ import com.github.jnidzwetzki.bitfinex.v2.commands.OrderCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.PingCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.SetConnectionFeaturesCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeCandlesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTickerCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTradesCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeOrderbookCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeRawOrderbookCommand;
+import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTickerCommand;
+import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTradesCommand;
 import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrder;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderType;
 import com.github.jnidzwetzki.bitfinex.v2.entity.OrderBookFrequency;
 import com.github.jnidzwetzki.bitfinex.v2.entity.OrderBookPrecision;
-import com.github.jnidzwetzki.bitfinex.v2.entity.Timeframe;
 import com.github.jnidzwetzki.bitfinex.v2.entity.OrderbookConfiguration;
 import com.github.jnidzwetzki.bitfinex.v2.entity.RawOrderbookConfiguration;
+import com.github.jnidzwetzki.bitfinex.v2.entity.Timeframe;
 import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexCandlestickSymbol;
-import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexTickerSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexExecutedTradeSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.entity.symbol.BitfinexTickerSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.util.BitfinexStreamSymbolToChannelIdResolverAware;
 
 public class CommandsTest {
 
@@ -71,12 +72,15 @@ public class CommandsTest {
 				new SubscribeTradesCommand(new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("BAT","BTC"))),
 				new SubscribeOrderbookCommand(orderbookConfiguration),
 				new SubscribeRawOrderbookCommand(rawOrderbookConfiguration),
-				new UnsubscribeChannelCommand(12),
+				new UnsubscribeChannelCommand(orderbookConfiguration),
 				new SetConnectionFeaturesCommand(new HashSet<>()));
 		
 		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
 		
 		for(final AbstractAPICommand command : commands) {
+			if (command instanceof BitfinexStreamSymbolToChannelIdResolverAware) {
+				((BitfinexStreamSymbolToChannelIdResolverAware) command).setResolver(s -> 12);
+			}
 			final String commandValue = command.getCommand(bitfinexApiBroker);
 			Assert.assertNotNull(commandValue);
 			Assert.assertTrue(commandValue.length() > 10);


### PR DESCRIPTION
BitfinexApiBroker#channelIdSymbolMap improvements:

BitfinexApiBroker#getChannelForSymbol(symbol) made private
BitfinexApiBroker.#removeChannelForSymbol(symbol) removed
Removed Quota check -- exception raised by server or by client makes no real difference - will address "50 channels requirement" in future PRs
