### PR TITLE
Aggregated minor refactors

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -46,7 +46,7 @@ cfManager.enableConnectionFeature(BitfinexConnectionFeature.SEQ_ALL);
 ```java
 
 final BitfinexCandlestickSymbol symbol
-	= new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), Timeframe.MINUTE_1);
+	= BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), Timeframe.MINUTE_1);
 
 // The consumer will be called on all received candles for the symbol
 final BiConsumer<BitfinexCandlestickSymbol, BitfinexCandle> callback = (sym, tick) -> {
@@ -71,7 +71,7 @@ final BiConsumer<BitfinexTickerSymbol, BitfinexTick> callback = (symbol, tick) -
 	System.out.format("Got BitfinexTick (%s) for symbol (%s)\n", tick, symbol);
 };
 
-final BitfinexTickerSymbol symbol = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("BTC","USD"));
+final BitfinexTickerSymbol symbol = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("BTC","USD"));
 
 final QuoteManager quoteManager = bitfinexApiBroker.getQuoteManager();
 quoteManager.registerTickCallback(symbol, callback);
@@ -128,7 +128,7 @@ rawOrderbookManager.unsubscribeOrderbook(orderbookConfiguration);
 
 ## Executed trade callbacks (all trades on the exchange)
 ```java
-final BitfinexExecutedTradeSymbol symbol = new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("BTC","USD"));
+final BitfinexExecutedTradeSymbol symbol = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BTC","USD"));
 
 final QuoteManager quoteManager = bitfinexClient.getQuoteManager();
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -178,16 +178,16 @@ public class BitfinexApiBroker implements Closeable {
 	private final static Logger logger = LoggerFactory.getLogger(BitfinexApiBroker.class);
 
 	public BitfinexApiBroker(BitfinexApiBrokerConfig config) {
-		this(config, new BitfinexApiCallbackRegistry());
+		this(config, new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 	}
 
-	public BitfinexApiBroker(BitfinexApiBrokerConfig config, BitfinexApiCallbackRegistry callbackRegistry) {
+	public BitfinexApiBroker(BitfinexApiBrokerConfig config, BitfinexApiCallbackRegistry callbackRegistry, SequenceNumberAuditor sequenceNumberAuditor) {
 		this.configuration = new BitfinexApiBrokerConfig(config);
 		this.callbackRegistry = callbackRegistry;
 
 		this.channelIdToHandlerMap = new ConcurrentHashMap<>();
 		this.permissions = BitfinexApiKeyPermissions.NO_PERMISSIONS;
-		this.sequenceNumberAuditor = new SequenceNumberAuditor();
+		this.sequenceNumberAuditor = sequenceNumberAuditor;
 		this.lastHeartbeat = new AtomicLong(0);
 		this.quoteManager = new QuoteManager(this, configuration.getExecutorService());
 		this.orderbookManager = new OrderbookManager(this, configuration.getExecutorService());
@@ -727,9 +727,5 @@ public class BitfinexApiBroker implements Closeable {
 
 	public ConnectionFeatureManager getConnectionFeatureManager() {
 		return connectionFeatureManager;
-	}
-
-	public SequenceNumberAuditor getSequenceNumberAuditor() {
-		return sequenceNumberAuditor;
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -51,13 +51,13 @@ import com.github.jnidzwetzki.bitfinex.v2.callback.command.DoNothingCommandCallb
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.ErrorCallback;
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.SubscribedCallback;
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.UnsubscribedCallback;
-import com.github.jnidzwetzki.bitfinex.v2.commands.AbstractAPICommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.AuthCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeCandlesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeOrderbookCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTickerCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTradesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.AuthCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeCandlesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTickerCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTradesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
@@ -330,7 +330,7 @@ public class BitfinexApiBroker implements Closeable {
 	 * Send a new API command
 	 * @param apiCommand
 	 */
-	public void sendCommand(final AbstractAPICommand apiCommand) {
+	public void sendCommand(final BitfinexCommand apiCommand) {
 		try {
 			if (apiCommand instanceof BitfinexStreamSymbolToChannelIdResolverAware) {
 				BitfinexStreamSymbolToChannelIdResolverAware aware = (BitfinexStreamSymbolToChannelIdResolverAware) apiCommand;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -188,7 +188,7 @@ public class BitfinexApiBroker implements Closeable {
 		this.channelIdToHandlerMap = new ConcurrentHashMap<>();
 		this.permissions = BitfinexApiKeyPermissions.NO_PERMISSIONS;
 		this.sequenceNumberAuditor = new SequenceNumberAuditor();
-		this.lastHeartbeat = new AtomicLong();
+		this.lastHeartbeat = new AtomicLong(0);
 		this.quoteManager = new QuoteManager(this, configuration.getExecutorService());
 		this.orderbookManager = new OrderbookManager(this, configuration.getExecutorService());
 		this.rawOrderbookManager = new RawOrderbookManager(this, configuration.getExecutorService());
@@ -303,7 +303,7 @@ public class BitfinexApiBroker implements Closeable {
 			orderInitCallback.close();
 
 			if (configuration.isHeartbeatThreadActive()) {
-				heartbeatThread = new Thread(new HeartbeatThread(this, websocketEndpoint));
+				heartbeatThread = new Thread(new HeartbeatThread(this, websocketEndpoint, lastHeartbeat::get));
 				heartbeatThread.start();
 			}
 		} catch (Exception e) {
@@ -679,10 +679,6 @@ public class BitfinexApiBroker implements Closeable {
 
 	public BitfinexApiKeyPermissions getApiKeyPermissions() {
 		return permissions;
-	}
-
-	public AtomicLong getLastHeartbeat() {
-		return lastHeartbeat;
 	}
 
 	public Collection<BitfinexStreamSymbol> getSubscribedChannels() {

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBroker.java
@@ -51,8 +51,8 @@ import com.github.jnidzwetzki.bitfinex.v2.callback.command.DoNothingCommandCallb
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.ErrorCallback;
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.SubscribedCallback;
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.UnsubscribedCallback;
-import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.AuthCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeCandlesCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTickerCommand;
@@ -74,6 +74,7 @@ import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexCandlestickSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexExecutedTradeSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.util.BitfinexStreamSymbolToChannelIdResolverAware;
 
@@ -237,7 +238,7 @@ public class BitfinexApiBroker implements Closeable {
 
 		final AuthCallback auth = new AuthCallback();
 		auth.onAuthenticationSuccessEvent(permissions -> {
-			BitfinexAccountSymbol symbol = new BitfinexAccountSymbol(configuration.getApiKey(), permissions);
+			BitfinexAccountSymbol symbol = BitfinexSymbols.account(configuration.getApiKey(), permissions);
 			AccountInfoHandler handler = new AccountInfoHandler(0, symbol);
 			handler.onHeartbeatEvent(timestamp -> this.updateConnectionHeartbeat());
 			handler.onPositionsEvent(callbackRegistry::acceptPositionsEvent);
@@ -250,7 +251,7 @@ public class BitfinexApiBroker implements Closeable {
 			callbackRegistry.acceptAuthenticationSuccessEvent(symbol);
 		});
 		auth.onAuthenticationFailedEvent(permissions -> {
-			BitfinexAccountSymbol symbol = new BitfinexAccountSymbol(configuration.getApiKey(), permissions);
+			BitfinexAccountSymbol symbol = BitfinexSymbols.account(configuration.getApiKey(), permissions);
 			callbackRegistry.acceptAuthenticationFailedEvent(symbol);
 		});
 		commandCallbacks.put("auth", auth);

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBrokerConfig.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexApiBrokerConfig.java
@@ -22,7 +22,7 @@ import java.util.function.Supplier;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
-import com.github.jnidzwetzki.bitfinex.v2.commands.AuthCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.AuthCommand;
 
 public class BitfinexApiBrokerConfig {
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/HeartbeatThread.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/HeartbeatThread.java
@@ -27,7 +27,7 @@ import org.bboxdb.commons.concurrent.ExceptionSafeRunnable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.jnidzwetzki.bitfinex.v2.commands.PingCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.PingCommand;
 import com.github.jnidzwetzki.bitfinex.v2.manager.QuoteManager;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.util.EventsInTimeslotManager;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/HeartbeatThread.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/HeartbeatThread.java
@@ -20,6 +20,7 @@ package com.github.jnidzwetzki.bitfinex.v2;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -71,17 +72,23 @@ public class HeartbeatThread extends ExceptionSafeRunnable {
 	private final EventsInTimeslotManager eventsInTimeslotManager;
 
 	/**
+	 * last heartbeat supplier
+	 */
+	private final Supplier<Long> lastHeartbeatSupplier;
+
+	/**
 	 * The Logger
 	 */
 	final static Logger logger = LoggerFactory.getLogger(HeartbeatThread.class);
 
-
 	/**
 	 * @param bitfinexApiBroker
 	 */
-	public HeartbeatThread(final BitfinexApiBroker bitfinexApiBroker, final WebsocketClientEndpoint websocketClientEndpoint) {
+	public HeartbeatThread(final BitfinexApiBroker bitfinexApiBroker, final WebsocketClientEndpoint websocketClientEndpoint,
+						   final Supplier<Long> lastHeartbeatSupplier) {
 		this.bitfinexApiBroker = bitfinexApiBroker;
 		this.websocketEndpoint = websocketClientEndpoint;
+		this.lastHeartbeatSupplier = lastHeartbeatSupplier;
 
 		this.eventsInTimeslotManager = new EventsInTimeslotManager(
 				MAX_RECONNECTS_IN_TIME,
@@ -153,7 +160,7 @@ public class HeartbeatThread extends ExceptionSafeRunnable {
 
 		final List<BitfinexStreamSymbol> outdatedSybols = heartbeatValues.entrySet().stream()
 			.filter(e -> e.getValue() + TICKER_TIMEOUT < currentTime)
-			.map(e -> e.getKey())
+			.map(Map.Entry::getKey)
 			.collect(Collectors.toList());
 
 		if(! outdatedSybols.isEmpty()) {
@@ -170,7 +177,7 @@ public class HeartbeatThread extends ExceptionSafeRunnable {
 	 * Send a heartbeat package on the connection
 	 */
 	private void sendHeartbeatIfNeeded() {
-		final long nextHeartbeat = bitfinexApiBroker.getLastHeartbeat().get() + HEARTBEAT;
+		final long nextHeartbeat = lastHeartbeatSupplier.get() + HEARTBEAT;
 
 		if(nextHeartbeat < System.currentTimeMillis()) {
 			logger.debug("Send heartbeat");
@@ -183,7 +190,7 @@ public class HeartbeatThread extends ExceptionSafeRunnable {
 	 * @return
 	 */
 	private boolean checkConnectionTimeout() {
-		final long heartbeatTimeout = bitfinexApiBroker.getLastHeartbeat().get() + CONNECTION_TIMEOUT;
+		final long heartbeatTimeout = lastHeartbeatSupplier.get() + CONNECTION_TIMEOUT;
 
 		if(heartbeatTimeout < System.currentTimeMillis()) {
 			logger.error("Heartbeat timeout reconnecting");

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/AuthCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/AuthCommand.java
@@ -15,7 +15,7 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -28,7 +28,7 @@ import org.json.JSONObject;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
-public class AuthCommand extends AbstractAPICommand {
+public class AuthCommand implements BitfinexCommand {
 
 	/**
 	 * The used auth algorithm

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/BitfinexCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/BitfinexCommand.java
@@ -15,13 +15,13 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
-public abstract class AbstractAPICommand {
+public interface BitfinexCommand {
 
-	public abstract String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException;
+	String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException;
 
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CalculateCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CalculateCommand.java
@@ -15,29 +15,28 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
-
-import org.json.JSONObject;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexCandlestickSymbol;
 
-public class SubscribeCandlesCommand extends AbstractAPICommand {
+public class CalculateCommand implements BitfinexCommand {
+	
+	/**
+	 * The symbol
+	 */
+	private String symbol;
 
-	private final BitfinexCandlestickSymbol symbol;
-
-	public SubscribeCandlesCommand(final BitfinexCandlestickSymbol symbol) {
+	public CalculateCommand(final String symbol) {
 		this.symbol = symbol;
 	}
 
 	@Override
 	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
-		final JSONObject subscribeJson = new JSONObject();
-		subscribeJson.put("event", "subscribe");
-		subscribeJson.put("channel", "candles");
-		subscribeJson.put("key", symbol.toBifinexCandlestickString());
-				
-		return subscribeJson.toString();
+		final StringBuilder sb = new StringBuilder();
+		sb.append("[0,\"calc\",null,[[\"");
+		sb.append(symbol);
+		sb.append("\"]]]");
+		
+		return sb.toString();
 	}
-
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderCommand.java
@@ -15,28 +15,36 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
-public class SubscribeTickerCommand extends AbstractAPICommand {
+public class CancelOrderCommand implements BitfinexCommand {
 
-	private String currencyPair;
+	/**
+	 * The cid
+	 */
+	private long id;
 
-	public SubscribeTickerCommand(final BitfinexTickerSymbol currencyPair) {
-		this.currencyPair = currencyPair.getBitfinexCurrencyPair().toBitfinexString();
+	public CancelOrderCommand(final long id) {
+		this.id = id;
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
-		final JSONObject subscribeJson = new JSONObject();
-		subscribeJson.put("event", "subscribe");
-		subscribeJson.put("channel", "ticker");
-		subscribeJson.put("symbol", currencyPair);
+	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
 		
-		return subscribeJson.toString();
+		final JSONObject cancelJson = new JSONObject();
+		cancelJson.put("id", id);
+		
+		final StringBuilder sb = new StringBuilder();
+		sb.append("[0,\"oc\", null, ");
+		sb.append(cancelJson.toString());
+		sb.append("]\n");
+				
+		return sb.toString();
 	}
+
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderGroupCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderGroupCommand.java
@@ -15,28 +15,35 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
+
+import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
-public class CalculateCommand extends AbstractAPICommand {
-	
+public class CancelOrderGroupCommand implements BitfinexCommand {
+
 	/**
-	 * The symbol
+	 * The order group
 	 */
-	private String symbol;
+	private int orderGroup;
 
-	public CalculateCommand(final String symbol) {
-		this.symbol = symbol;
+	public CancelOrderGroupCommand(final int orderGroup) {
+		this.orderGroup = orderGroup;
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
-		final StringBuilder sb = new StringBuilder();
-		sb.append("[0,\"calc\",null,[[\"");
-		sb.append(symbol);
-		sb.append("\"]]]");
+	public String getCommand(BitfinexApiBroker bitfinexApiBroker) throws CommandException {
+		final JSONObject cancelJson = new JSONObject();
+		cancelJson.put("gid", orderGroup);
 		
+		final StringBuilder sb = new StringBuilder();
+		sb.append("[0,\"oc_multi\", null, ");
+		sb.append(cancelJson.toString());
+		sb.append("]\n");
+				
 		return sb.toString();
 	}
+
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/OrderCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/OrderCommand.java
@@ -15,7 +15,7 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -25,7 +25,7 @@ import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexNewOrder;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
-public class OrderCommand extends AbstractAPICommand {
+public class OrderCommand implements BitfinexCommand {
 
 	private final BitfinexNewOrder bitfinexOrder;
 	

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/PingCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/PingCommand.java
@@ -15,28 +15,19 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexExecutedTradeSymbol;
 
-public class SubscribeTradesCommand extends AbstractAPICommand {
-
-	private String currencyPair;
-
-	public SubscribeTradesCommand(final BitfinexExecutedTradeSymbol tradeSymbol) {
-		this.currencyPair = tradeSymbol.getBitfinexCurrencyPair().toBitfinexString();
-	}
+public class PingCommand implements BitfinexCommand {
 
 	@Override
 	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
 		final JSONObject subscribeJson = new JSONObject();
-		subscribeJson.put("event", "subscribe");
-		subscribeJson.put("channel", "trades");
-		subscribeJson.put("symbol", currencyPair);
-		
+		subscribeJson.put("event", "ping");
 		return subscribeJson.toString();
 	}
+
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SetConnectionFeaturesCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SetConnectionFeaturesCommand.java
@@ -15,35 +15,39 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
+
+import java.util.Collection;
 
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
 
-public class CancelOrderGroupCommand extends AbstractAPICommand {
+public class SetConnectionFeaturesCommand implements BitfinexCommand {
 
 	/**
-	 * The order group
+	 * The active features
 	 */
-	private int orderGroup;
+	private Collection<BitfinexConnectionFeature> features;
 
-	public CancelOrderGroupCommand(final int orderGroup) {
-		this.orderGroup = orderGroup;
+	public SetConnectionFeaturesCommand(final Collection<BitfinexConnectionFeature> features) {
+		this.features = features;
 	}
-
+	
 	@Override
-	public String getCommand(BitfinexApiBroker bitfinexApiBroker) throws CommandException {
-		final JSONObject cancelJson = new JSONObject();
-		cancelJson.put("gid", orderGroup);
+	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
 		
-		final StringBuilder sb = new StringBuilder();
-		sb.append("[0,\"oc_multi\", null, ");
-		sb.append(cancelJson.toString());
-		sb.append("]\n");
-				
-		return sb.toString();
+		// XOR all features
+		int featureFlags = 0;
+		for(final BitfinexConnectionFeature feature : features) {
+			featureFlags = featureFlags ^ feature.getFeatureFlag();
+		}
+		
+		final JSONObject subscribeJson = new JSONObject();
+		subscribeJson.put("event", "conf");
+		subscribeJson.put("flags", featureFlags);
+		return subscribeJson.toString();
 	}
 
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeCandlesCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeCandlesCommand.java
@@ -15,36 +15,29 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexCandlestickSymbol;
 
-public class CancelOrderCommand extends AbstractAPICommand {
+public class SubscribeCandlesCommand implements BitfinexCommand {
 
-	/**
-	 * The cid
-	 */
-	private long id;
+	private final BitfinexCandlestickSymbol symbol;
 
-	public CancelOrderCommand(final long id) {
-		this.id = id;
+	public SubscribeCandlesCommand(final BitfinexCandlestickSymbol symbol) {
+		this.symbol = symbol;
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
-		
-		final JSONObject cancelJson = new JSONObject();
-		cancelJson.put("id", id);
-		
-		final StringBuilder sb = new StringBuilder();
-		sb.append("[0,\"oc\", null, ");
-		sb.append(cancelJson.toString());
-		sb.append("]\n");
+	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+		final JSONObject subscribeJson = new JSONObject();
+		subscribeJson.put("event", "subscribe");
+		subscribeJson.put("channel", "candles");
+		subscribeJson.put("key", symbol.toBifinexCandlestickString());
 				
-		return sb.toString();
+		return subscribeJson.toString();
 	}
 
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeOrderbookCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeOrderbookCommand.java
@@ -15,18 +15,38 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;
 
-public class PingCommand extends AbstractAPICommand {
+public class SubscribeOrderbookCommand implements BitfinexCommand {
+
+	/**
+	 * The orderbook configuration
+	 */
+	private BitfinexOrderBookSymbol symbol;
+	
+	public SubscribeOrderbookCommand(final BitfinexOrderBookSymbol symbol) {
+		this.symbol = symbol;
+	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
 		final JSONObject subscribeJson = new JSONObject();
-		subscribeJson.put("event", "ping");
+		subscribeJson.put("event", "subscribe");
+		subscribeJson.put("channel", "book");
+		subscribeJson.put("symbol", symbol.getCurrencyPair().toBitfinexString());
+		subscribeJson.put("prec", symbol.getPrecision().toString());
+		if (symbol.getFrequency() != null) {
+			subscribeJson.put("freq", symbol.getFrequency().toString());
+		}
+		if (symbol.getPricePoints() != null) {
+			subscribeJson.put("len", Integer.toString(symbol.getPricePoints()));
+		}
 		return subscribeJson.toString();
 	}
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTickerCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTickerCommand.java
@@ -15,39 +15,28 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
 
-public class SubscribeOrderbookCommand extends AbstractAPICommand {
+public class SubscribeTickerCommand implements BitfinexCommand {
 
-	/**
-	 * The orderbook configuration
-	 */
-	private BitfinexOrderBookSymbol symbol;
-	
-	public SubscribeOrderbookCommand(final BitfinexOrderBookSymbol symbol) {
-		this.symbol = symbol;
+	private String currencyPair;
+
+	public SubscribeTickerCommand(final BitfinexTickerSymbol currencyPair) {
+		this.currencyPair = currencyPair.getBitfinexCurrencyPair().toBitfinexString();
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
+	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "subscribe");
-		subscribeJson.put("channel", "book");
-		subscribeJson.put("symbol", symbol.getCurrencyPair().toBitfinexString());
-		subscribeJson.put("prec", symbol.getPrecision().toString());
-		if (symbol.getFrequency() != null) {
-			subscribeJson.put("freq", symbol.getFrequency().toString());
-		}
-		if (symbol.getPricePoints() != null) {
-			subscribeJson.put("len", Integer.toString(symbol.getPricePoints()));
-		}
+		subscribeJson.put("channel", "ticker");
+		subscribeJson.put("symbol", currencyPair);
+		
 		return subscribeJson.toString();
 	}
-
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTradesCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTradesCommand.java
@@ -15,39 +15,28 @@
  *    limitations under the License. 
  *    
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
-
-import java.util.Collection;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexExecutedTradeSymbol;
 
-public class SetConnectionFeaturesCommand extends AbstractAPICommand {
+public class SubscribeTradesCommand implements BitfinexCommand {
 
-	/**
-	 * The active features
-	 */
-	private Collection<BitfinexConnectionFeature> features;
+	private String currencyPair;
 
-	public SetConnectionFeaturesCommand(final Collection<BitfinexConnectionFeature> features) {
-		this.features = features;
+	public SubscribeTradesCommand(final BitfinexExecutedTradeSymbol tradeSymbol) {
+		this.currencyPair = tradeSymbol.getBitfinexCurrencyPair().toBitfinexString();
 	}
-	
+
 	@Override
 	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
-		
-		// XOR all features
-		int featureFlags = 0;
-		for(final BitfinexConnectionFeature feature : features) {
-			featureFlags = featureFlags ^ feature.getFeatureFlag();
-		}
-		
 		final JSONObject subscribeJson = new JSONObject();
-		subscribeJson.put("event", "conf");
-		subscribeJson.put("flags", featureFlags);
+		subscribeJson.put("event", "subscribe");
+		subscribeJson.put("channel", "trades");
+		subscribeJson.put("symbol", currencyPair);
+		
 		return subscribeJson.toString();
 	}
-
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/UnsubscribeChannelCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/UnsubscribeChannelCommand.java
@@ -15,7 +15,7 @@
  *    limitations under the License. 
  *
  *******************************************************************************/
-package com.github.jnidzwetzki.bitfinex.v2.commands;
+package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import java.util.Objects;
 import java.util.function.Function;
@@ -26,7 +26,7 @@ import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.util.BitfinexStreamSymbolToChannelIdResolverAware;
 
-public class UnsubscribeChannelCommand extends AbstractAPICommand implements BitfinexStreamSymbolToChannelIdResolverAware {
+public class UnsubscribeChannelCommand implements BitfinexCommand, BitfinexStreamSymbolToChannelIdResolverAware {
 
 	/**
 	 * The channel to unsubscribe

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/ConnectionFeatureManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/ConnectionFeatureManager.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Sets;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SetConnectionFeaturesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SetConnectionFeaturesCommand;
 
 public class ConnectionFeatureManager extends AbstractManager {
 	

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderManager.java
@@ -31,9 +31,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.commands.CancelOrderCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.CancelOrderGroupCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.OrderCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.CancelOrderCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.CancelOrderGroupCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.OrderCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexNewOrder;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexSubmittedOrder;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeOrderbookCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderBookEntry;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/QuoteManager.java
@@ -25,10 +25,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeCandlesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTickerCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTradesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeCandlesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTickerCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTradesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandle;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexExecutedTrade;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexTick;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeOrderbookCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderBookEntry;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/WalletManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/WalletManager.java
@@ -25,7 +25,7 @@ import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.commands.CalculateCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.CalculateCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexWallet;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexAccountSymbol.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexAccountSymbol.java
@@ -9,7 +9,7 @@ public class BitfinexAccountSymbol implements BitfinexStreamSymbol {
     private final String apiKey;
     private final BitfinexApiKeyPermissions permissions;
 
-    public BitfinexAccountSymbol(String apiKey, BitfinexApiKeyPermissions permissions) {
+    BitfinexAccountSymbol(String apiKey, BitfinexApiKeyPermissions permissions) {
         this.apiKey = apiKey;
         this.permissions = permissions;
     }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexCandlestickSymbol.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexCandlestickSymbol.java
@@ -32,7 +32,7 @@ public class BitfinexCandlestickSymbol implements BitfinexStreamSymbol {
 	 */
 	private final BitfinexCandleTimeFrame timeframe;
 
-	public BitfinexCandlestickSymbol(final BitfinexCurrencyPair symbol, final BitfinexCandleTimeFrame timeframe) {
+	BitfinexCandlestickSymbol(final BitfinexCurrencyPair symbol, final BitfinexCandleTimeFrame timeframe) {
 		this.symbol = symbol;
 		this.timeframe = timeframe;
 	}
@@ -72,8 +72,8 @@ public class BitfinexCandlestickSymbol implements BitfinexStreamSymbol {
 		
 		final String timeframeString = splitString[1];
 		final String symbolString = splitString[2];
-		
-		return new BitfinexCandlestickSymbol(
+
+		return BitfinexSymbols.candlesticks(
 				BitfinexCurrencyPair.fromSymbolString(symbolString), 
 				BitfinexCandleTimeFrame.fromSymbolString(timeframeString));
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexExecutedTradeSymbol.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexExecutedTradeSymbol.java
@@ -26,7 +26,7 @@ public class BitfinexExecutedTradeSymbol implements BitfinexStreamSymbol {
 	 */
 	private final BitfinexCurrencyPair bitfinexCurrencyPair;
 
-	public BitfinexExecutedTradeSymbol(final BitfinexCurrencyPair bitfinexCurrencyPair) {
+	BitfinexExecutedTradeSymbol(final BitfinexCurrencyPair bitfinexCurrencyPair) {
 		this.bitfinexCurrencyPair = bitfinexCurrencyPair;
 	}
 
@@ -64,7 +64,7 @@ public class BitfinexExecutedTradeSymbol implements BitfinexStreamSymbol {
 	 */
 	public static BitfinexExecutedTradeSymbol fromBitfinexString(final String symbol) {
 		final BitfinexCurrencyPair bitfinexCurrencyPair = BitfinexCurrencyPair.fromSymbolString(symbol);
-		return new BitfinexExecutedTradeSymbol(bitfinexCurrencyPair);
+		return BitfinexSymbols.executedTrades(bitfinexCurrencyPair);
 	}
 
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexSymbols.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexSymbols.java
@@ -1,35 +1,157 @@
 package com.github.jnidzwetzki.bitfinex.v2.symbol;
 
+import java.util.Objects;
+
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 
+/**
+ * Bitfinex symbol factory class
+ */
 public final class BitfinexSymbols {
 
     private BitfinexSymbols() {
 
     }
 
-    public static BitfinexCandlestickSymbol candlesticks(BitfinexCurrencyPair currencyPair, BitfinexCandleTimeFrame timeframe) {
-        return new BitfinexCandlestickSymbol(currencyPair, timeframe);
+    /**
+     * Returns symbol for account.
+     * used only within lib - no practical use for end-user
+     *
+     * @param apiKey      for this account
+     * @param permissions of specified key
+     * @return symbol
+     */
+    public static BitfinexAccountSymbol account(String apiKey, BitfinexApiKeyPermissions permissions) {
+        return new BitfinexAccountSymbol(apiKey, permissions);
     }
 
+    /**
+     * Returns symbol for candlestick channel
+     *
+     * @param currencyPair of candles
+     * @param timeframe    configuration of candles
+     * @return symbol
+     */
+    public static BitfinexCandlestickSymbol candlesticks(BitfinexCurrencyPair currencyPair, BitfinexCandleTimeFrame timeframe) {
+        return new BitfinexCandlestickSymbol(currencyPair, Objects.requireNonNull(timeframe));
+    }
+
+    /**
+     * Returns symbol for candlestick channel
+     *
+     * @param currency       of candles
+     * @param profitCurrency of candles
+     * @param timeframe      configuration of candles
+     * @return symbol
+     */
+    public static BitfinexCandlestickSymbol candlesticks(String currency, String profitCurrency, BitfinexCandleTimeFrame timeframe) {
+        currency = Objects.requireNonNull(currency).toUpperCase();
+        profitCurrency = Objects.requireNonNull(profitCurrency).toUpperCase();
+        return candlesticks(BitfinexCurrencyPair.of(currency, profitCurrency), timeframe);
+    }
+
+    /**
+     * Returns symbol for executed trades channel
+     *
+     * @param currencyPair of trades channel
+     * @return symbol
+     */
     public static BitfinexExecutedTradeSymbol executedTrades(BitfinexCurrencyPair currencyPair) {
         return new BitfinexExecutedTradeSymbol(currencyPair);
     }
 
+    /**
+     * Returns symbol for candlestick channel
+     *
+     * @param currency       of trades channel
+     * @param profitCurrency of trades channel
+     * @return symbol
+     */
+    public static BitfinexExecutedTradeSymbol executedTrades(String currency, String profitCurrency) {
+        currency = Objects.requireNonNull(currency).toUpperCase();
+        profitCurrency = Objects.requireNonNull(profitCurrency).toUpperCase();
+        return executedTrades(BitfinexCurrencyPair.of(currency, profitCurrency));
+    }
+
+    /**
+     * returns symbol for raw order book channel
+     *
+     * @param currencyPair of raw order book channel
+     * @return symbol
+     */
     public static BitfinexOrderBookSymbol rawOrderBook(BitfinexCurrencyPair currencyPair) {
         return new BitfinexOrderBookSymbol(currencyPair, BitfinexOrderBookSymbol.Precision.R0, null, null);
     }
 
+    /**
+     * Returns symbol for raw order book channel
+     *
+     * @param currency       of raw order book channel
+     * @param profitCurrency of raw order book channel
+     * @return symbol
+     */
+    public static BitfinexOrderBookSymbol rawOrderBook(String currency, String profitCurrency) {
+        currency = Objects.requireNonNull(currency).toUpperCase();
+        profitCurrency = Objects.requireNonNull(profitCurrency).toUpperCase();
+        return rawOrderBook(BitfinexCurrencyPair.of(currency, profitCurrency));
+    }
+
+    /**
+     * returns symbol for order book channel
+     *
+     * @param currencyPair of order book channel
+     * @param precision    of order book
+     * @param frequency    of order book
+     * @param pricePoints  in initial snapshot
+     * @return symbol
+     */
     public static BitfinexOrderBookSymbol orderBook(BitfinexCurrencyPair currencyPair, BitfinexOrderBookSymbol.Precision precision,
                                                     BitfinexOrderBookSymbol.Frequency frequency, int pricePoints) {
         if (precision == BitfinexOrderBookSymbol.Precision.R0) {
-            throw new IllegalArgumentException("Use BitfinexSymbols#rawOrderBook() method instead");
+            throw new IllegalArgumentException("Use BitfinexSymbols#rawOrderBook() factory method instead");
         }
         return new BitfinexOrderBookSymbol(currencyPair, precision, frequency, pricePoints);
     }
 
+    /**
+     * Returns symbol for candlestick channel
+     *
+     * @param currency       of order book
+     * @param profitCurrency of order book
+     * @param precision      of order book
+     * @param frequency      of order book
+     * @param pricePoints    in initial snapshot
+     * @return symbol
+     */
+    public static BitfinexOrderBookSymbol orderBook(String currency, String profitCurrency, BitfinexOrderBookSymbol.Precision precision,
+                                                    BitfinexOrderBookSymbol.Frequency frequency, int pricePoints) {
+        currency = Objects.requireNonNull(currency).toUpperCase();
+        profitCurrency = Objects.requireNonNull(profitCurrency).toUpperCase();
+        return orderBook(BitfinexCurrencyPair.of(currency, profitCurrency), precision, frequency, pricePoints);
+    }
+
+    /**
+     * returns symbol for ticker channel
+     *
+     * @param currencyPair of ticker channel
+     * @return symbol
+     */
     public static BitfinexTickerSymbol ticker(BitfinexCurrencyPair currencyPair) {
         return new BitfinexTickerSymbol(currencyPair);
+    }
+
+    /**
+     * returns symbol for ticker channel
+     *
+     * @param currency       of ticker
+     * @param profitCurrency of ticker
+     * @return symbol
+     */
+    public static BitfinexTickerSymbol ticker(String currency, String profitCurrency) {
+        currency = Objects.requireNonNull(currency).toUpperCase();
+        profitCurrency = Objects.requireNonNull(profitCurrency).toUpperCase();
+        return ticker(BitfinexCurrencyPair.of(currency, profitCurrency));
     }
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexTickerSymbol.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/symbol/BitfinexTickerSymbol.java
@@ -26,7 +26,7 @@ public class BitfinexTickerSymbol implements BitfinexStreamSymbol {
 	 */
 	private final BitfinexCurrencyPair bitfinexCurrencyPair;
 
-	public BitfinexTickerSymbol(final BitfinexCurrencyPair bitfinexCurrencyPair) {
+	BitfinexTickerSymbol(final BitfinexCurrencyPair bitfinexCurrencyPair) {
 		this.bitfinexCurrencyPair = bitfinexCurrencyPair;
 	}
 
@@ -64,7 +64,7 @@ public class BitfinexTickerSymbol implements BitfinexStreamSymbol {
 	 */
 	public static BitfinexTickerSymbol fromBitfinexString(final String symbol) {
 		final BitfinexCurrencyPair bitfinexCurrencyPair = BitfinexCurrencyPair.fromSymbolString(symbol);
-		return new BitfinexTickerSymbol(bitfinexCurrencyPair);
+		return BitfinexSymbols.ticker(bitfinexCurrencyPair);
 	}
 
 	/**

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/BitfinexPositionTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/BitfinexPositionTest.java
@@ -29,10 +29,10 @@ import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.account.info.PositionHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexPosition;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.PositionManager;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexAccountSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 
 
 public class BitfinexPositionTest {
@@ -48,7 +48,7 @@ public class BitfinexPositionTest {
 		final JSONArray jsonArray = new JSONArray(jsonString);
 
 		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
-		final PositionHandler positionHandler = new PositionHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+		final PositionHandler positionHandler = new PositionHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		positionHandler.onPositionsEvent((a, positions) -> {
 			for (BitfinexPosition position : positions) {
 				bitfinexApiBroker.getPositionManager().updatePosition(position);
@@ -71,7 +71,7 @@ public class BitfinexPositionTest {
 		final JSONArray jsonArray = new JSONArray(jsonString);
 
 		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
-		final PositionHandler positionHandler = new PositionHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+		final PositionHandler positionHandler = new PositionHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		positionHandler.onPositionsEvent((a, positions) -> {
 			for (BitfinexPosition position : positions) {
 				bitfinexApiBroker.getPositionManager().updatePosition(position);
@@ -94,7 +94,7 @@ public class BitfinexPositionTest {
 		final JSONArray jsonArray = new JSONArray(jsonString);
 
 		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
-		final PositionHandler positionHandler = new PositionHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+		final PositionHandler positionHandler = new PositionHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		positionHandler.onPositionsEvent((a, positions) -> {
 			for (BitfinexPosition position : positions) {
 				bitfinexApiBroker.getPositionManager().updatePosition(position);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsCallbackTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsCallbackTest.java
@@ -17,16 +17,17 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.test;
 
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.AuthCallback;
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.ConnectionHeartbeatCallback;
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.SubscribedCallback;
 import com.github.jnidzwetzki.bitfinex.v2.callback.command.UnsubscribedCallback;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
-import org.json.JSONObject;
-import org.junit.Assert;
-import org.junit.Test;
 
 public class CommandsCallbackTest {
 	

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
@@ -11,20 +11,20 @@ import org.mockito.Mockito;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexOrderBuilder;
-import com.github.jnidzwetzki.bitfinex.v2.commands.AbstractAPICommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.AuthCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.CancelOrderCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.CancelOrderGroupCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.AuthCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.CancelOrderCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.CancelOrderGroupCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexNewOrder;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
-import com.github.jnidzwetzki.bitfinex.v2.commands.OrderCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.PingCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SetConnectionFeaturesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeCandlesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeOrderbookCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTickerCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.SubscribeTradesCommand;
-import com.github.jnidzwetzki.bitfinex.v2.commands.UnsubscribeChannelCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.OrderCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.PingCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SetConnectionFeaturesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeCandlesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTickerCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTradesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderType;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
@@ -55,7 +55,7 @@ public class CommandsTest {
 
 		BitfinexOrderBookSymbol rawOrderbookConfiguration = BitfinexSymbols.rawOrderBook(BitfinexCurrencyPair.of("BAT", "BTC"));
 
-		final List<AbstractAPICommand> commands = Arrays.asList(
+		final List<BitfinexCommand> commands = Arrays.asList(
 				new AuthCommand(AuthCommand.AUTH_NONCE_PRODUCER_TIMESTAMP),
 				new CancelOrderCommand(123),
 				new CancelOrderGroupCommand(1),
@@ -71,7 +71,7 @@ public class CommandsTest {
 
 		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
 
-		for(final AbstractAPICommand command : commands) {
+		for(final BitfinexCommand command : commands) {
 			if (command instanceof BitfinexStreamSymbolToChannelIdResolverAware) {
 				((BitfinexStreamSymbolToChannelIdResolverAware) command).setResolver(s -> 12);
 			}

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
@@ -11,12 +11,10 @@ import org.mockito.Mockito;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexOrderBuilder;
-import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.AuthCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.CancelOrderCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.CancelOrderGroupCommand;
-import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexNewOrder;
-import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 import com.github.jnidzwetzki.bitfinex.v2.command.OrderCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.PingCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.SetConnectionFeaturesCommand;
@@ -25,14 +23,14 @@ import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTickerCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTradesCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
-import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
-import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderType;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexNewOrder;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderType;
+import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexCandlestickSymbol;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexExecutedTradeSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.util.BitfinexStreamSymbolToChannelIdResolverAware;
 
 public class CommandsTest {
@@ -62,8 +60,8 @@ public class CommandsTest {
 				new OrderCommand(order),
 				new PingCommand(),
 				new SubscribeCandlesCommand(candleSymbol),
-				new SubscribeTickerCommand(new BitfinexTickerSymbol(BitfinexCurrencyPair.of("BCH","USD"))),
-				new SubscribeTradesCommand(new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("BAT","BTC"))),
+				new SubscribeTickerCommand(BitfinexSymbols.ticker(BitfinexCurrencyPair.of("BCH","USD"))),
+				new SubscribeTradesCommand(BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BAT","BTC"))),
 				new SubscribeOrderbookCommand(orderbookConfiguration),
 				new SubscribeOrderbookCommand(rawOrderbookConfiguration),
 				new UnsubscribeChannelCommand(orderbookConfiguration),

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/HeartbeatManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/HeartbeatManagerTest.java
@@ -30,11 +30,10 @@ import com.github.jnidzwetzki.bitfinex.v2.HeartbeatThread;
 import com.github.jnidzwetzki.bitfinex.v2.WebsocketClientEndpoint;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.HeartbeatHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexAccountSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 
 
 public class HeartbeatManagerTest {
@@ -82,7 +81,7 @@ public class HeartbeatManagerTest {
 	 */
 	@Test
 	public void testHeartbeatHandler() throws APIException, InterruptedException {
-		final HeartbeatHandler handler = new HeartbeatHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+		final HeartbeatHandler handler = new HeartbeatHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		long heartbeat = System.currentTimeMillis();
 		handler.onHeartbeatEvent(timestamp -> Assert.assertTrue(timestamp > heartbeat));
 		Thread.sleep(50);
@@ -104,7 +103,7 @@ public class HeartbeatManagerTest {
 	@Test
 	public void testTickerFreshness2() {
 		final HashMap<BitfinexStreamSymbol, Long> heartbeatValues = new HashMap<>();
-		heartbeatValues.put(new BitfinexTickerSymbol(BitfinexCurrencyPair.of("AGI","ETH")), System.currentTimeMillis());
+		heartbeatValues.put(BitfinexSymbols.ticker(BitfinexCurrencyPair.of("AGI","ETH")), System.currentTimeMillis());
 		Assert.assertTrue(HeartbeatThread.checkTickerFreshness(heartbeatValues));
 	}
 
@@ -115,7 +114,7 @@ public class HeartbeatManagerTest {
 	public void testTickerFreshness3() {
 		final HashMap<BitfinexStreamSymbol, Long> heartbeatValues = new HashMap<>();
 		long outdatedTime = System.currentTimeMillis() - HeartbeatThread.TICKER_TIMEOUT - 10;
-		heartbeatValues.put(new BitfinexTickerSymbol(BitfinexCurrencyPair.of("AGI","ETH")), outdatedTime);
+		heartbeatValues.put(BitfinexSymbols.ticker(BitfinexCurrencyPair.of("AGI","ETH")), outdatedTime);
 		Assert.assertFalse(HeartbeatThread.checkTickerFreshness(heartbeatValues));
 	}
 }

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/HeartbeatManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/HeartbeatManagerTest.java
@@ -19,6 +19,7 @@ package com.github.jnidzwetzki.bitfinex.v2.test;
 
 import java.util.HashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,7 +58,8 @@ public class HeartbeatManagerTest {
 
 		final WebsocketClientEndpoint websocketClientEndpoint = Mockito.mock(WebsocketClientEndpoint.class);
 		Mockito.when(websocketClientEndpoint.isConnected()).thenReturn(connectLatch.getCount() == 0);
-		final HeartbeatThread heartbeatThreadRunnable = new HeartbeatThread(bitfinexApiBroker, websocketClientEndpoint);
+		AtomicLong heartbeat = new AtomicLong(0);
+		final HeartbeatThread heartbeatThreadRunnable = new HeartbeatThread(bitfinexApiBroker, websocketClientEndpoint, heartbeat::get);
 
 		Mockito.doAnswer(answer).when(bitfinexApiBroker).reconnect();
 		Mockito.doAnswer(answer).when(websocketClientEndpoint).close();

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
@@ -30,11 +30,11 @@ import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
 import com.github.jnidzwetzki.bitfinex.v2.SequenceNumberAuditor;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandle;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexExecutedTrade;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderBookEntry;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexTick;
-import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexExecutedTrade;
-import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.ConnectionFeatureManager;
 import com.github.jnidzwetzki.bitfinex.v2.manager.OrderbookManager;
@@ -172,9 +172,9 @@ public class IntegrationTest {
 		try {
 			bitfinexClient.connect();
 			final List<BitfinexCandlestickSymbol> symbols = Arrays.asList(
-						new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1),
-						new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.DAY_1),
-						new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MONTH_1)
+						BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1),
+						BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.DAY_1),
+						BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MONTH_1)
 						);
 
 			final QuoteManager orderbookManager = bitfinexClient.getQuoteManager();
@@ -216,7 +216,7 @@ public class IntegrationTest {
 		final CountDownLatch latch = new CountDownLatch(2);
 		try {
 			bitfinexClient.connect();
-			final BitfinexExecutedTradeSymbol symbol = new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("BTC","USD"));
+			final BitfinexExecutedTradeSymbol symbol = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BTC","USD"));
 
 			final QuoteManager executedTradeManager = bitfinexClient.getQuoteManager();
 
@@ -251,8 +251,8 @@ public class IntegrationTest {
 
 		try {
 			bitfinexClient.connect();
-			final BitfinexExecutedTradeSymbol symbol1 = new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("BTC","USD"));
-			final BitfinexExecutedTradeSymbol symbol2 = new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("ETH","USD"));
+			final BitfinexExecutedTradeSymbol symbol1 = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BTC","USD"));
+			final BitfinexExecutedTradeSymbol symbol2 = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("ETH","USD"));
 
 			final QuoteManager quoteManager = bitfinexClient.getQuoteManager();
 
@@ -284,7 +284,7 @@ public class IntegrationTest {
 		final CountDownLatch latch = new CountDownLatch(2);
 		try {
 			bitfinexClient.connect();
-			final BitfinexTickerSymbol symbol = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("BTC","USD"));
+			final BitfinexTickerSymbol symbol = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("BTC","USD"));
 
 			final QuoteManager orderbookManager = bitfinexClient.getQuoteManager();
 
@@ -347,7 +347,7 @@ public class IntegrationTest {
 		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
 		bitfinexClient.connect();
 
-		final BitfinexTickerSymbol symbol = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("BTC","USD"));
+		final BitfinexTickerSymbol symbol = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("BTC","USD"));
 
 		final QuoteManager orderbookManager = bitfinexClient.getQuoteManager();
 
@@ -398,11 +398,11 @@ public class IntegrationTest {
 		Assert.assertEquals(BitfinexConnectionFeature.SEQ_ALL.getFeatureFlag(), cfManager.getActiveConnectionFeatures());
 
 		// Register some ticket to get some sequence numbers
-		final BitfinexTickerSymbol symbol1 = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("BTC","USD"));
-		final BitfinexTickerSymbol symbol2 = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("ETH","USD"));
-		final BitfinexTickerSymbol symbol3 = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("EOS","USD"));
-		final BitfinexTickerSymbol symbol4 = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("IOS","USD"));
-		final BitfinexTickerSymbol symbol5 = new BitfinexTickerSymbol(BitfinexCurrencyPair.of("NEO","USD"));
+		final BitfinexTickerSymbol symbol1 = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("BTC","USD"));
+		final BitfinexTickerSymbol symbol2 = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("ETH","USD"));
+		final BitfinexTickerSymbol symbol3 = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("EOS","USD"));
+		final BitfinexTickerSymbol symbol4 = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("IOS","USD"));
+		final BitfinexTickerSymbol symbol5 = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("NEO","USD"));
 
 		final QuoteManager orderbookManager = bitfinexClient.getQuoteManager();
 
@@ -438,7 +438,7 @@ public class IntegrationTest {
 		final CountDownLatch latch = new CountDownLatch(5);
 		try {
 			bitfinexClient.connect();
-			final BitfinexCandlestickSymbol symbol = new BitfinexCandlestickSymbol(
+			final BitfinexCandlestickSymbol symbol = BitfinexSymbols.candlesticks(
 					BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1);
 
 			final QuoteManager orderbookManager = bitfinexClient.getQuoteManager();

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
 import com.github.jnidzwetzki.bitfinex.v2.SequenceNumberAuditor;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandle;
@@ -381,10 +382,10 @@ public class IntegrationTest {
 	 */
 	@Test
 	public void testSequencing() throws APIException, InterruptedException {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		SequenceNumberAuditor sequenceNumberAuditor = new SequenceNumberAuditor();
+		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig(), new BitfinexApiCallbackRegistry(), sequenceNumberAuditor);
 		bitfinexClient.connect();
 
-		final SequenceNumberAuditor sequenceNumberAuditor = bitfinexClient.getSequenceNumberAuditor();
 		Assert.assertEquals(-1, sequenceNumberAuditor.getPrivateSequence());
 		Assert.assertEquals(-1, sequenceNumberAuditor.getPublicSequence());
 		Assert.assertEquals(SequenceNumberAuditor.ErrorPolicy.LOG_ONLY, sequenceNumberAuditor.getErrorPolicy());

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexExecutedTradesHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexExecutedTradesHandlerTest.java
@@ -28,10 +28,11 @@ import org.mockito.Mockito;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.ExecutedTradeHandler;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexExecutedTradeSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.QuoteManager;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexExecutedTradeSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 
 public class BitfinexExecutedTradesHandlerTest {
 
@@ -53,7 +54,7 @@ public class BitfinexExecutedTradesHandlerTest {
         final JSONArray jsonArray = new JSONArray(callbackValue);
 
         final BitfinexExecutedTradeSymbol symbol
-                = new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("BTC", "USD"));
+                = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BTC", "USD"));
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
         final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
@@ -86,7 +87,7 @@ public class BitfinexExecutedTradesHandlerTest {
         final JSONArray jsonArray = new JSONArray(callbackValue);
 
         final BitfinexExecutedTradeSymbol symbol
-                = new BitfinexExecutedTradeSymbol(BitfinexCurrencyPair.of("BTC", "USD"));
+                = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BTC", "USD"));
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
         final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexWalletHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexWalletHandlerTest.java
@@ -27,10 +27,10 @@ import org.mockito.Mockito;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.account.info.WalletHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexWallet;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.WalletManager;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexAccountSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 
 
 public class BitfinexWalletHandlerTest {
@@ -61,7 +61,7 @@ public class BitfinexWalletHandlerTest {
 
 		Assert.assertTrue(walletTable.isEmpty());
 		
-		final WalletHandler walletHandler = new WalletHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+		final WalletHandler walletHandler = new WalletHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		walletHandler.onWalletsEvent((a, wallets) -> {
 			for (BitfinexWallet wallet : wallets) {
 				try {
@@ -101,7 +101,7 @@ public class BitfinexWalletHandlerTest {
 
 		Assert.assertTrue(walletTable.isEmpty());
 		
-		final WalletHandler walletHandler = new WalletHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+		final WalletHandler walletHandler = new WalletHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		walletHandler.onWalletsEvent((a, wallets) -> {
 			for (BitfinexWallet wallet : wallets) {
 				try {

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/CandlestickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/CandlestickHandlerTest.java
@@ -29,11 +29,12 @@ import org.mockito.Mockito;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.CandlestickHandler;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
-import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexCandlestickSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.QuoteManager;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexCandlestickSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 
 
 public class CandlestickHandlerTest {
@@ -54,7 +55,7 @@ public class CandlestickHandlerTest {
 		final JSONArray jsonArray = new JSONArray(callbackValue);
 		
 		final BitfinexCandlestickSymbol symbol 
-			= new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1);
+			= BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1);
 
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
 		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
@@ -94,7 +95,7 @@ public class CandlestickHandlerTest {
 		final JSONArray jsonArray = new JSONArray(callbackValue);
 		
 		final BitfinexCandlestickSymbol symbol 
-			= new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1);
+			= BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1);
 
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
 		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
@@ -138,10 +139,10 @@ public class CandlestickHandlerTest {
 	@Test
 	public void testCandlestickSymbolEncoding1() {
 		final BitfinexCandlestickSymbol symbol1 
-			= new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BCH","USD"), BitfinexCandleTimeFrame.MINUTES_15);
+			= BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BCH","USD"), BitfinexCandleTimeFrame.MINUTES_15);
 		
 		final BitfinexCandlestickSymbol symbol2
-			= new BitfinexCandlestickSymbol(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_15);
+			= BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_15);
 	
 		Assert.assertFalse(symbol1.equals(symbol2));
 		

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/TickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/TickHandlerTest.java
@@ -28,10 +28,11 @@ import org.mockito.Mockito;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.TickHandler;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.QuoteManager;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
 
 
 public class TickHandlerTest {
@@ -53,7 +54,7 @@ public class TickHandlerTest {
         final JSONArray jsonArray = new JSONArray(callbackValue);
 
         final BitfinexCurrencyPair currencyPair = BitfinexCurrencyPair.of("BTC", "USD");
-        final BitfinexTickerSymbol symbol = new BitfinexTickerSymbol(currencyPair);
+        final BitfinexTickerSymbol symbol = BitfinexSymbols.ticker(currencyPair);
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
         final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/OrderManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/OrderManagerTest.java
@@ -37,6 +37,7 @@ import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexSubmittedOrderStatus;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.OrderManager;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexAccountSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 
 
 public class OrderManagerTest {
@@ -61,7 +62,7 @@ public class OrderManagerTest {
 
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
         bitfinexApiBroker.getOrderManager().registerCallback(orderCallback);
-        final NotificationHandler notificationHandler = new NotificationHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final NotificationHandler notificationHandler = new NotificationHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         notificationHandler.onOrderNotification((a, eo) -> {
             bitfinexApiBroker.getOrderManager().updateOrder(a, eo);
         });
@@ -90,7 +91,7 @@ public class OrderManagerTest {
 
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
         bitfinexApiBroker.getOrderManager().registerCallback(orderCallback);
-        final NotificationHandler notificationHandler = new NotificationHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final NotificationHandler notificationHandler = new NotificationHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 
         notificationHandler.handleChannelData(null, jsonArray);
         notificationHandler.onOrderNotification((a, eo) -> {
@@ -108,7 +109,7 @@ public class OrderManagerTest {
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
         final String jsonString = "[0,\"on\",[6784335053,null,1514956504945000,\"tIOTUSD\",1514956505134,1514956505164,-24.175121,-24.175121,\"EXCHANGE STOP\",null,null,null,0,\"ACTIVE\",null,null,3.84,0,null,null,null,null,null,0,0,0]]";
         final JSONArray jsonArray = new JSONArray(jsonString);
-        final OrderHandler orderHandler = new OrderHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final OrderHandler orderHandler = new OrderHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         orderHandler.onSubmittedOrderEvent((a, eos) -> {
             for (BitfinexSubmittedOrder exchangeOrder : eos) {
                 bitfinexApiBroker.getOrderManager().updateOrder(a, exchangeOrder);
@@ -133,7 +134,7 @@ public class OrderManagerTest {
         final String jsonString = "[0,\"on\",[[6784335053,null,1514956504945000,\"tIOTUSD\",1514956505134,1514956505164,-24.175121,-24.175121,\"EXCHANGE STOP\",null,null,null,0,\"ACTIVE\",null,null,3.84,0,null,null,null,null,null,0,0,0], [67843353243,null,1514956234945000,\"tBTCUSD\",1514956505134,1514956505164,-24.175121,-24.175121,\"EXCHANGE STOP\",null,null,null,0,\"ACTIVE\",null,null,3.84,0,null,null,null,null,null,0,0,0]]]";
         final JSONArray jsonArray = new JSONArray(jsonString);
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
-        final OrderHandler orderHandler = new OrderHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final OrderHandler orderHandler = new OrderHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         orderHandler.onSubmittedOrderEvent((a, eos) -> {
             for (BitfinexSubmittedOrder exchangeOrder : eos) {
                 bitfinexApiBroker.getOrderManager().updateOrder(a, exchangeOrder);
@@ -163,7 +164,7 @@ public class OrderManagerTest {
 
         final JSONArray jsonArray = new JSONArray(jsonString);
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
-        final OrderHandler orderHandler = new OrderHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final OrderHandler orderHandler = new OrderHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         orderHandler.onSubmittedOrderEvent((a,eos) -> {
             for (BitfinexSubmittedOrder exchangeOrder : eos) {
                 bitfinexApiBroker.getOrderManager().updateOrder(a, exchangeOrder);
@@ -188,7 +189,7 @@ public class OrderManagerTest {
 
         final JSONArray jsonArray = new JSONArray(jsonString);
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
-        final OrderHandler orderHandler = new OrderHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final OrderHandler orderHandler = new OrderHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         orderHandler.onSubmittedOrderEvent((a, eos) -> {
             for (BitfinexSubmittedOrder exchangeOrder : eos) {
                 bitfinexApiBroker.getOrderManager().updateOrder(a, exchangeOrder);
@@ -229,7 +230,7 @@ public class OrderManagerTest {
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
 
         final OrderManager orderManager = bitfinexApiBroker.getOrderManager();
-        BitfinexAccountSymbol symbol = new BitfinexAccountSymbol("apiKey", BitfinexApiKeyPermissions.ALL_PERMISSIONS);
+        BitfinexAccountSymbol symbol = BitfinexSymbols.account("apiKey", BitfinexApiKeyPermissions.ALL_PERMISSIONS);
 
         final Runnable r = () -> {
             try {
@@ -286,7 +287,7 @@ public class OrderManagerTest {
 
         final BitfinexNewOrder order
                 = BitfinexOrderBuilder.create(BitfinexCurrencyPair.of("BCH", "USD"), BitfinexOrderType.MARKET, 1).build();
-        BitfinexAccountSymbol symbol = new BitfinexAccountSymbol("apiKey", BitfinexApiKeyPermissions.ALL_PERMISSIONS);
+        BitfinexAccountSymbol symbol = BitfinexSymbols.account("apiKey", BitfinexApiKeyPermissions.ALL_PERMISSIONS);
 
         final Runnable r = () -> {
             try {

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TradeManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TradeManagerTest.java
@@ -29,12 +29,12 @@ import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.account.info.MyExecutedTradeHandler;
-import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderType;
-import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 import com.github.jnidzwetzki.bitfinex.v2.manager.TradeManager;
-import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexAccountSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
 
 public class TradeManagerTest {
 
@@ -60,7 +60,7 @@ public class TradeManagerTest {
         final String jsonString = "[0,\"te\",[106655593,\"tBTCUSD\",1512247319827,5691690918,-0.002,10894,null,null,-1]]";
         final JSONArray jsonArray = new JSONArray(jsonString);
         final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
-        final MyExecutedTradeHandler tradeHandler = new MyExecutedTradeHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final MyExecutedTradeHandler tradeHandler = new MyExecutedTradeHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         tradeHandler.onTradeEvent((a, trade) -> bitfinexApiBroker.getTradeManager().updateTrade(a, trade));
 
         bitfinexApiBroker.getTradeManager().registerCallback((t) -> {
@@ -90,7 +90,7 @@ public class TradeManagerTest {
 
         final JSONArray jsonArray = new JSONArray(jsonString);
         final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
-        final MyExecutedTradeHandler tradeHandler = new MyExecutedTradeHandler(0, new BitfinexAccountSymbol("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
+        final MyExecutedTradeHandler tradeHandler = new MyExecutedTradeHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         tradeHandler.onTradeEvent((a, trade) -> bitfinexApiBroker.getTradeManager().updateTrade(a, trade));
 
         bitfinexApiBroker.getTradeManager().registerCallback((t) -> {


### PR DESCRIPTION
Hi Jan,
- BitfinexApiBroker: SequenceNumberAuditor can be shared between instances (used for websocket client pooling)
we should share sequence auditor between all instances, this is a must-have for multi websocket connection pools

- HeartbeatThread: last heartbeat provided through supplier
BitfinexApiBroker#getLastheartbeat() refactored out - no real usefulness to end-user

- BitfinexSymbols: symbols made package-private, user is forced to use factory class
Forcing end-users to use BitfinexSymbol factory methods instead of creating new instances of symbols (and getting to know the API - easier entry level)

- Commands: APICommand made an interface, and renamed to BitfinexCommand
APICommand is too general, and since this class may possibly be used by end-user, better to make it more specific in name

This is my last refactoring PR - library seems a lil'bit different now :) I will prepare websocket "pooled" broker in next PR. Nextly I will do some work around junits and documentation.

Cheers,
-- miron