### PR TITLE
Pooled WebSocket Client

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexClientFactory.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexClientFactory.java
@@ -1,0 +1,31 @@
+package com.github.jnidzwetzki.bitfinex.v2;
+
+public final class BitfinexClientFactory {
+
+    private BitfinexClientFactory() {
+
+    }
+
+    /**
+     * bitfinex client
+     *
+     * @param config - config
+     * @return {@link SimpleBitfinexApiBroker} client
+     */
+    public static BitfinexWebsocketClient singleClient(BitfinexWebsocketConfiguration config) {
+        return new SimpleBitfinexApiBroker(config, new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
+    }
+
+    /**
+     * bitfinex client with subscribed channel managed.
+     * spreads amount of subscribed channels across multiple websocket physical connections.
+     *
+     * @param config                - config
+     * @param channelsPerConnection - channels per client - 25 - 150 (limit by bitfinex exchange)
+     * @return {@link PooledBitfinexApiBroker} client
+     */
+    public static BitfinexWebsocketClient pooledClient(BitfinexWebsocketConfiguration config, int channelsPerConnection) {
+        return new PooledBitfinexApiBroker(config, new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor(), channelsPerConnection);
+    }
+
+}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexWebsocketClient.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexWebsocketClient.java
@@ -1,0 +1,55 @@
+package com.github.jnidzwetzki.bitfinex.v2;
+
+import java.util.Collection;
+
+import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
+import com.github.jnidzwetzki.bitfinex.v2.manager.ConnectionFeatureManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.OrderManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.OrderbookManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.PositionManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.QuoteManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.RawOrderbookManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.TradeManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.WalletManager;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
+
+public interface BitfinexWebsocketClient {
+
+    void connect() throws APIException;
+
+    void close();
+
+    void sendCommand(BitfinexCommand command);
+
+    boolean reconnect();
+
+    boolean unsubscribeAllChannels();
+
+    boolean isAuthenticated();
+
+    BitfinexApiKeyPermissions getApiKeyPermissions();
+
+    Collection<BitfinexStreamSymbol> getSubscribedChannels();
+
+    BitfinexWebsocketConfiguration getConfiguration();
+
+    BitfinexApiCallbackListeners getCallbacks();
+
+    QuoteManager getQuoteManager();
+
+    OrderbookManager getOrderbookManager();
+
+    RawOrderbookManager getRawOrderbookManager();
+
+    PositionManager getPositionManager();
+
+    OrderManager getOrderManager();
+
+    TradeManager getTradeManager();
+
+    WalletManager getWalletManager();
+
+    ConnectionFeatureManager getConnectionFeatureManager();
+}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexWebsocketConfiguration.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/BitfinexWebsocketConfiguration.java
@@ -24,22 +24,59 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import com.github.jnidzwetzki.bitfinex.v2.command.AuthCommand;
 
-public class BitfinexApiBrokerConfig {
+public class BitfinexWebsocketConfiguration {
 
+    /**
+     * api key
+     */
     private String apiKey;
+
+    /**
+     * api secret
+     */
     private String apiSecret;
+
+    /**
+     * false if euthentication should be skipped
+     */
     private boolean authenticationEnabled = false;
+
+    /**
+     * false if heartbeat thread should not be running
+     */
     private boolean heartbeatThreadActive = true;
+
+    /**
+     * false if deadman switch should not be active
+     */
     private boolean deadmanSwitchActive = false;
+
+    /**
+     * false if managers should not be active
+     */
     private boolean managersActive = true;
+
+    /**
+     * authentication nonce producer
+     */
     private Supplier<String> authNonceProducer = AuthCommand.AUTH_NONCE_PRODUCER_TIMESTAMP;
+
+    /**
+     * executor service used by managers
+     */
     private ExecutorService executorService = MoreExecutors.newDirectExecutorService();
 
-    public BitfinexApiBrokerConfig() {
+    /**
+     * delay in millis used by {@link PooledBitfinexApiBroker}.
+     * Server will throw 429 on #connect() if too low.
+     */
+    private int connectionEstablishingDelay = 7_500;
+
+    public BitfinexWebsocketConfiguration() {
 
     }
 
-    public BitfinexApiBrokerConfig(final BitfinexApiBrokerConfig copy) {
+    public BitfinexWebsocketConfiguration(final BitfinexWebsocketConfiguration copy) {
         this.apiKey = copy.apiKey;
         this.apiSecret = copy.apiSecret;
         this.authenticationEnabled = copy.authenticationEnabled;
@@ -48,6 +85,7 @@ public class BitfinexApiBrokerConfig {
         this.managersActive = copy.managersActive;
         this.authNonceProducer = copy.authNonceProducer;
         this.executorService = copy.executorService;
+        this.connectionEstablishingDelay = copy.connectionEstablishingDelay;
     }
 
     public void setApiCredentials(final String apiKey, final String apiSecret) {
@@ -110,5 +148,13 @@ public class BitfinexApiBrokerConfig {
 
     public void setExecutorService(final ExecutorService executorService) {
         this.executorService = executorService;
+    }
+
+    public int getConnectionEstablishingDelay() {
+        return connectionEstablishingDelay;
+    }
+
+    public void setConnectionEstablishingDelay(int connectionEstablishingDelay) {
+        this.connectionEstablishingDelay = connectionEstablishingDelay;
     }
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/PooledBitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/PooledBitfinexApiBroker.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ *
+ *    Copyright (C) 2015-2018 Jan Kristof Nidzwetzki
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ *******************************************************************************/
+package com.github.jnidzwetzki.bitfinex.v2;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
+import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
+import com.github.jnidzwetzki.bitfinex.v2.manager.ConnectionFeatureManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.OrderManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.OrderbookManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.PositionManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.QuoteManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.RawOrderbookManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.TradeManager;
+import com.github.jnidzwetzki.bitfinex.v2.manager.WalletManager;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.util.EventsInTimeslotManager;
+
+/**
+ * BitfinexApiBroker client spreading amount of channels across multiple websocket connections.
+ */
+public class PooledBitfinexApiBroker implements BitfinexWebsocketClient {
+
+    private final AtomicInteger numberOfClients = new AtomicInteger(0);
+    private final Map<Integer, BitfinexWebsocketClient> clients = new ConcurrentHashMap<>();
+    private final Map<BitfinexWebsocketClient, Set<BitfinexStreamSymbol>> pendingSubscriptions = new ConcurrentHashMap<>();
+
+    private final BitfinexWebsocketConfiguration configuration;
+    private final BitfinexApiCallbackRegistry callbackRegistry;
+    private final SequenceNumberAuditor sequenceNumberAuditor;
+    private final int maxChannelsPerClient;
+
+    private final EventsInTimeslotManager connectEventManager;
+
+    private final QuoteManager quoteManager;
+    private final OrderbookManager orderbookManager;
+    private final RawOrderbookManager rawOrderbookManager;
+    private final OrderManager orderManager;
+    private final TradeManager tradeManager;
+    private final PositionManager positionManager;
+    private final WalletManager walletManager;
+    private final ConnectionFeatureManager connectionFeatureManager;
+
+    public PooledBitfinexApiBroker(final BitfinexWebsocketConfiguration config, final BitfinexApiCallbackRegistry callbacks,
+                                   final SequenceNumberAuditor seqNoAuditor, final int channelsPerConnection) {
+        if (channelsPerConnection < 50 || channelsPerConnection > 250) {
+            throw new IllegalArgumentException("channelsPerConnection must be in range (50,250)");
+        }
+        configuration = new BitfinexWebsocketConfiguration(config);
+        callbackRegistry = callbacks;
+        sequenceNumberAuditor = seqNoAuditor;
+        maxChannelsPerClient = channelsPerConnection;
+
+        connectEventManager = new EventsInTimeslotManager(1, configuration.getConnectionEstablishingDelay(), TimeUnit.MILLISECONDS);
+
+        quoteManager = new QuoteManager(this, configuration.getExecutorService());
+        orderbookManager = new OrderbookManager(this, configuration.getExecutorService());
+        rawOrderbookManager = new RawOrderbookManager(this, configuration.getExecutorService());
+        orderManager = new OrderManager(this, configuration.getExecutorService());
+        tradeManager = new TradeManager(this, configuration.getExecutorService());
+        positionManager = new PositionManager(this, configuration.getExecutorService());
+        walletManager = new WalletManager(this, configuration.getExecutorService());
+        connectionFeatureManager = new ConnectionFeatureManager(this, configuration.getExecutorService());
+
+        callbackRegistry.onSubscribeChannelEvent(sym -> pendingSubscriptions.forEach((client, symbols) -> symbols.remove(sym)));
+        callbackRegistry.onUnsubscribeChannelEvent(sym -> pendingSubscriptions.forEach((client, symbols) -> symbols.remove(sym)));
+
+        SimpleBitfinexApiBroker authClient = new SimpleBitfinexApiBroker(configuration, callbackRegistry, seqNoAuditor);
+        clients.put(numberOfClients.getAndIncrement(), authClient);
+        pendingSubscriptions.put(authClient, ConcurrentHashMap.newKeySet());
+    }
+
+    @Override
+    public void connect() throws APIException {
+        clients.values().forEach(BitfinexWebsocketClient::connect);
+    }
+
+    @Override
+    public void close() {
+        clients.values().forEach(BitfinexWebsocketClient::close);
+    }
+
+    @Override
+    public void sendCommand(BitfinexCommand command) {
+        BitfinexWebsocketClient client = clients.get(0);
+        if (command instanceof SubscribeCommand) {
+            BitfinexStreamSymbol symbol = ((SubscribeCommand) command).getSymbol();
+            synchronized (this) {
+                client = clients.values().stream()
+                        .filter(c -> {
+                            int subscribed = c.getSubscribedChannels().size();
+                            int pending = pendingSubscriptions.get(c).size();
+                            return subscribed + pending < maxChannelsPerClient;
+                        })
+                        .findFirst().orElseGet(this::createAndConnectClient);
+                pendingSubscriptions.get(client).add(symbol);
+            }
+        }
+        if (command instanceof UnsubscribeChannelCommand) {
+            UnsubscribeChannelCommand unsubscribeCommand = (UnsubscribeChannelCommand) command;
+            BitfinexStreamSymbol symbol = unsubscribeCommand.getSymbol();
+            client = clients.values().stream()
+                    .filter(c -> c.getSubscribedChannels().contains(symbol))
+                    .findFirst().orElseThrow(IllegalStateException::new);
+        }
+        client.sendCommand(command);
+    }
+
+    public int websocketConnCount() {
+        return numberOfClients.get();
+    }
+
+    @Override
+    public boolean reconnect() {
+        boolean retVal = false;
+        for (BitfinexWebsocketClient client : clients.values()) {
+            retVal |= client.reconnect();
+        }
+        return retVal;
+    }
+
+    @Override
+    public boolean unsubscribeAllChannels() {
+        boolean retVal = true;
+        for (BitfinexWebsocketClient client : clients.values()) {
+            retVal &= client.unsubscribeAllChannels();
+        }
+        return retVal;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        boolean retVal = false;
+        for (BitfinexWebsocketClient client : clients.values()) {
+            retVal |= client.isAuthenticated();
+        }
+        return retVal;
+    }
+
+    @Override
+    public BitfinexApiKeyPermissions getApiKeyPermissions() {
+        return clients.get(0).getApiKeyPermissions();
+    }
+
+    @Override
+    public Collection<BitfinexStreamSymbol> getSubscribedChannels() {
+        return clients.values().stream()
+                .flatMap(c -> c.getSubscribedChannels().stream())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public BitfinexWebsocketConfiguration getConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public BitfinexApiCallbackListeners getCallbacks() {
+        return callbackRegistry;
+    }
+
+    @Override
+    public QuoteManager getQuoteManager() {
+        return quoteManager;
+    }
+
+    @Override
+    public OrderbookManager getOrderbookManager() {
+        return orderbookManager;
+    }
+
+    @Override
+    public RawOrderbookManager getRawOrderbookManager() {
+        return rawOrderbookManager;
+    }
+
+    @Override
+    public PositionManager getPositionManager() {
+        return positionManager;
+    }
+
+    @Override
+    public OrderManager getOrderManager() {
+        return orderManager;
+    }
+
+    @Override
+    public TradeManager getTradeManager() {
+        return tradeManager;
+    }
+
+    @Override
+    public WalletManager getWalletManager() {
+        return walletManager;
+    }
+
+    @Override
+    public ConnectionFeatureManager getConnectionFeatureManager() {
+        return connectionFeatureManager;
+    }
+
+    private BitfinexWebsocketClient createAndConnectClient() {
+        BitfinexWebsocketConfiguration config = new BitfinexWebsocketConfiguration(configuration);
+        config.setAuthenticationEnabled(false);
+        config.setManagersActive(false);
+        SimpleBitfinexApiBroker client = new SimpleBitfinexApiBroker(config, callbackRegistry, sequenceNumberAuditor);
+        clients.put(numberOfClients.getAndIncrement(), client);
+        if (connectEventManager.getNumberOfEventsInTimeslot() > 1) {
+            try {
+                connectEventManager.waitForNewTimeslot();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        connectEventManager.recordNewEvent();
+        pendingSubscriptions.put(client, ConcurrentHashMap.newKeySet());
+        client.connect();
+        return client;
+    }
+}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/WebsocketClientEndpoint.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/WebsocketClientEndpoint.java
@@ -32,6 +32,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import com.google.common.base.Throwables;
@@ -59,7 +60,7 @@ public class WebsocketClientEndpoint implements Closeable {
 	/**
 	 * The Logger
 	 */
-	private final static Logger logger = LoggerFactory.getLogger(BitfinexApiBroker.class);
+	private final static Logger logger = LoggerFactory.getLogger(SimpleBitfinexApiBroker.class);
 
 	/**
 	 * The wait for connection latch
@@ -82,7 +83,7 @@ public class WebsocketClientEndpoint implements Closeable {
 		final WebSocketContainer container = ContainerProvider.getWebSocketContainer();
 		connectLatch = new CountDownLatch(1);
 		this.userSession = container.connectToServer(this, endpointURI);
-		connectLatch.await();
+		connectLatch.await(15, TimeUnit.SECONDS);
 	}
 
 	@OnOpen

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/CandlestickHandler.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/channel/CandlestickHandler.java
@@ -48,20 +48,22 @@ public class CandlestickHandler implements ChannelCallbackHandler {
      * {@inheritDoc}
      */
     @Override
-    public void handleChannelData(final String action, final JSONArray jsonArray) throws APIException {
-
+    public void handleChannelData(final String action, final JSONArray payload) throws APIException {
+        if (payload.isEmpty()) {
+            return;
+        }
         // channel symbol trade:1m:tLTCUSD
         final Set<BitfinexCandle> candlestickList = new TreeSet<>(Comparator.comparing(BitfinexCandle::getTimestamp));
 
         // Snapshots contain multiple Bars, Updates only one
-        if (jsonArray.get(0) instanceof JSONArray) {
-            for (int pos = 0; pos < jsonArray.length(); pos++) {
-                final JSONArray parts = jsonArray.getJSONArray(pos);
+        if (payload.get(0) instanceof JSONArray) {
+            for (int pos = 0; pos < payload.length(); pos++) {
+                final JSONArray parts = payload.getJSONArray(pos);
                 BitfinexCandle candlestick = jsonToCandlestick(parts);
                 candlestickList.add(candlestick);
             }
         } else {
-            BitfinexCandle candlestick = jsonToCandlestick(jsonArray);
+            BitfinexCandle candlestick = jsonToCandlestick(payload);
             candlestickList.add(candlestick);
         }
         candlesConsumer.accept(symbol, candlestickList);

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/command/SubscribedCallback.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/command/SubscribedCallback.java
@@ -62,7 +62,6 @@ public class SubscribedCallback implements CommandCallbackHandler {
 				logger.error("Unknown subscribed callback {}", jsonObject.toString());
 		}
 		if (symbol != null) {
-			logger.info("Registering symbol {} on channel {}", symbol, channelId);
 			subscribeResultConsumer.accept(channelId, symbol);
 		}
 	}
@@ -79,10 +78,8 @@ public class SubscribedCallback implements CommandCallbackHandler {
 		BitfinexStreamSymbol symbol;
 		if("R0".equals(jsonObject.getString("prec"))) {
 			symbol = BitfinexOrderBookSymbol.fromJSON(jsonObject);
-			logger.info("Registering raw book {}", jsonObject);
 		} else {
 			symbol = BitfinexOrderBookSymbol.fromJSON(jsonObject);
-			logger.info("Registering book {}", jsonObject);
 		}
 		return symbol;
 	}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/command/UnsubscribedCallback.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/callback/command/UnsubscribedCallback.java
@@ -37,7 +37,6 @@ public class UnsubscribedCallback implements CommandCallbackHandler {
 	public void handleChannelData(final JSONObject jsonObject) throws APIException {
 		final int channelId = jsonObject.getInt("chanId");
 		unsubscribedConsumer.accept(channelId);
-		logger.info("Channel {} ({}) is unsubscribed", channelId);
 	}
 
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/AuthCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/AuthCommand.java
@@ -25,7 +25,7 @@ import java.util.function.Supplier;
 import com.google.common.io.BaseEncoding;
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
 public class AuthCommand implements BitfinexCommand {
@@ -50,11 +50,11 @@ public class AuthCommand implements BitfinexCommand {
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
+	public String getCommand(final BitfinexWebsocketClient client) throws CommandException {
 		try {
-			final String APIKey = bitfinexApiBroker.getConfiguration().getApiKey();
-			final String APISecret = bitfinexApiBroker.getConfiguration().getApiSecret();
-			final boolean deadManSwitch = bitfinexApiBroker.getConfiguration().isDeadmanSwitchActive();
+			final String APIKey = client.getConfiguration().getApiKey();
+			final String APISecret = client.getConfiguration().getApiSecret();
+			final boolean deadManSwitch = client.getConfiguration().isDeadmanSwitchActive();
 			
 			final String authNonce = authNonceSupplier.get();
 			final String authPayload = "AUTH" + authNonce;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/BitfinexCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/BitfinexCommand.java
@@ -17,11 +17,11 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.command;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
 public interface BitfinexCommand {
 
-	String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException;
+	String getCommand(final BitfinexWebsocketClient client) throws CommandException;
 
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CalculateCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CalculateCommand.java
@@ -17,7 +17,7 @@
  *******************************************************************************/
 package com.github.jnidzwetzki.bitfinex.v2.command;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 
 public class CalculateCommand implements BitfinexCommand {
 	
@@ -31,7 +31,7 @@ public class CalculateCommand implements BitfinexCommand {
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexWebsocketClient client) {
 		final StringBuilder sb = new StringBuilder();
 		sb.append("[0,\"calc\",null,[[\"");
 		sb.append(symbol);

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderCommand.java
@@ -19,7 +19,7 @@ package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
 public class CancelOrderCommand implements BitfinexCommand {
@@ -34,7 +34,7 @@ public class CancelOrderCommand implements BitfinexCommand {
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
+	public String getCommand(final BitfinexWebsocketClient client) throws CommandException {
 		
 		final JSONObject cancelJson = new JSONObject();
 		cancelJson.put("id", id);

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderGroupCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/CancelOrderGroupCommand.java
@@ -19,7 +19,7 @@ package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
 public class CancelOrderGroupCommand implements BitfinexCommand {
@@ -34,7 +34,7 @@ public class CancelOrderGroupCommand implements BitfinexCommand {
 	}
 
 	@Override
-	public String getCommand(BitfinexApiBroker bitfinexApiBroker) throws CommandException {
+	public String getCommand(BitfinexWebsocketClient client) throws CommandException {
 		final JSONObject cancelJson = new JSONObject();
 		cancelJson.put("gid", orderGroup);
 		

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/OrderCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/OrderCommand.java
@@ -21,7 +21,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexNewOrder;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 
@@ -39,7 +39,7 @@ public class OrderCommand implements BitfinexCommand {
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
+	public String getCommand(final BitfinexWebsocketClient client) throws CommandException {
 		
 		final JSONObject orderJson = new JSONObject();
 		orderJson.put("type", bitfinexOrder.getOrderType().getBifinexString());

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/PingCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/PingCommand.java
@@ -19,12 +19,12 @@ package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 
 public class PingCommand implements BitfinexCommand {
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexWebsocketClient client) {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "ping");
 		return subscribeJson.toString();

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SetConnectionFeaturesCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SetConnectionFeaturesCommand.java
@@ -21,8 +21,8 @@ import java.util.Collection;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 
 public class SetConnectionFeaturesCommand implements BitfinexCommand {
 
@@ -36,7 +36,7 @@ public class SetConnectionFeaturesCommand implements BitfinexCommand {
 	}
 	
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexWebsocketClient client) {
 		
 		// XOR all features
 		int featureFlags = 0;

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeCandlesCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeCandlesCommand.java
@@ -19,10 +19,11 @@ package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexCandlestickSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
 
-public class SubscribeCandlesCommand implements BitfinexCommand {
+public class SubscribeCandlesCommand implements SubscribeCommand {
 
 	private final BitfinexCandlestickSymbol symbol;
 
@@ -31,7 +32,7 @@ public class SubscribeCandlesCommand implements BitfinexCommand {
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexWebsocketClient client) {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "subscribe");
 		subscribeJson.put("channel", "candles");
@@ -40,4 +41,8 @@ public class SubscribeCandlesCommand implements BitfinexCommand {
 		return subscribeJson.toString();
 	}
 
+	@Override
+	public BitfinexStreamSymbol getSymbol() {
+		return symbol;
+	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeCommand.java
@@ -1,0 +1,8 @@
+package com.github.jnidzwetzki.bitfinex.v2.command;
+
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
+
+public interface SubscribeCommand extends BitfinexCommand {
+
+    BitfinexStreamSymbol getSymbol();
+}

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeOrderbookCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeOrderbookCommand.java
@@ -19,11 +19,12 @@ package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.exception.CommandException;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
 
-public class SubscribeOrderbookCommand implements BitfinexCommand {
+public class SubscribeOrderbookCommand implements SubscribeCommand {
 
 	/**
 	 * The orderbook configuration
@@ -35,7 +36,7 @@ public class SubscribeOrderbookCommand implements BitfinexCommand {
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) throws CommandException {
+	public String getCommand(final BitfinexWebsocketClient client) throws CommandException {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "subscribe");
 		subscribeJson.put("channel", "book");
@@ -50,4 +51,8 @@ public class SubscribeOrderbookCommand implements BitfinexCommand {
 		return subscribeJson.toString();
 	}
 
+	@Override
+	public BitfinexStreamSymbol getSymbol() {
+		return symbol;
+	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTickerCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTickerCommand.java
@@ -19,24 +19,32 @@ package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexTickerSymbol;
 
-public class SubscribeTickerCommand implements BitfinexCommand {
+public class SubscribeTickerCommand implements SubscribeCommand {
 
-	private String currencyPair;
+	private final BitfinexTickerSymbol symbol;
+	private final String currencyPair;
 
 	public SubscribeTickerCommand(final BitfinexTickerSymbol currencyPair) {
+		this.symbol = currencyPair;
 		this.currencyPair = currencyPair.getBitfinexCurrencyPair().toBitfinexString();
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexWebsocketClient client) {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "subscribe");
 		subscribeJson.put("channel", "ticker");
 		subscribeJson.put("symbol", currencyPair);
 		
 		return subscribeJson.toString();
+	}
+
+	@Override
+	public BitfinexStreamSymbol getSymbol() {
+		return symbol;
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTradesCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/SubscribeTradesCommand.java
@@ -19,24 +19,32 @@ package com.github.jnidzwetzki.bitfinex.v2.command;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexExecutedTradeSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
 
-public class SubscribeTradesCommand implements BitfinexCommand {
+public class SubscribeTradesCommand implements SubscribeCommand {
 
-	private String currencyPair;
+	private final BitfinexExecutedTradeSymbol symbol;
+	private final String currencyPair;
 
 	public SubscribeTradesCommand(final BitfinexExecutedTradeSymbol tradeSymbol) {
+		this.symbol = tradeSymbol;
 		this.currencyPair = tradeSymbol.getBitfinexCurrencyPair().toBitfinexString();
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexWebsocketClient client) {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "subscribe");
 		subscribeJson.put("channel", "trades");
 		subscribeJson.put("symbol", currencyPair);
 		
 		return subscribeJson.toString();
+	}
+
+	@Override
+	public BitfinexStreamSymbol getSymbol() {
+		return symbol;
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/UnsubscribeChannelCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/UnsubscribeChannelCommand.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 
 import org.json.JSONObject;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexStreamSymbol;
 import com.github.jnidzwetzki.bitfinex.v2.util.BitfinexStreamSymbolToChannelIdResolverAware;
 
@@ -41,12 +41,16 @@ public class UnsubscribeChannelCommand implements BitfinexCommand, BitfinexStrea
 	}
 
 	@Override
-	public String getCommand(final BitfinexApiBroker bitfinexApiBroker) {
+	public String getCommand(final BitfinexWebsocketClient client) {
 		final JSONObject subscribeJson = new JSONObject();
 		subscribeJson.put("event", "unsubscribe");
 		subscribeJson.put("chanId", channelIdResolver.apply(symbol));
 
 		return subscribeJson.toString();
+	}
+
+	public BitfinexStreamSymbol getSymbol() {
+		return symbol;
 	}
 
 	@Override

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexCurrencyPair.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexCurrencyPair.java
@@ -206,7 +206,6 @@ public class BitfinexCurrencyPair {
 		register("XVG", "JPY", 26.0);
 		register("BCI", "USD", 26.0);
 		register("BCI", "BTC", 26.0);
-		register("BCI", "ETH", 26.0);
 	}
 
 	/**
@@ -347,5 +346,10 @@ public class BitfinexCurrencyPair {
 	 */
 	public String getCurrency2() {
 		return currency2;
+	}
+
+	@Override
+	public String toString() {
+		return currency1 + ":" + currency2;
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/AbstractManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/AbstractManager.java
@@ -19,7 +19,7 @@ package com.github.jnidzwetzki.bitfinex.v2.manager;
 
 import java.util.concurrent.ExecutorService;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 
 public abstract class AbstractManager {
 	
@@ -31,13 +31,11 @@ public abstract class AbstractManager {
 	/**
 	 * The bitfinex API broker
 	 */
-	protected final BitfinexApiBroker bitfinexApiBroker;
+	protected final BitfinexWebsocketClient client;
 
-	public AbstractManager(final BitfinexApiBroker bitfinexApiBroker, 
-			final ExecutorService executorService) {
-		
+	public AbstractManager(final BitfinexWebsocketClient client, final ExecutorService executorService) {
 		this.executorService = executorService;
-		this.bitfinexApiBroker = bitfinexApiBroker;
+		this.client = client;
 	}
 
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/BiConsumerCallbackManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/BiConsumerCallbackManager.java
@@ -25,7 +25,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
 
 public class BiConsumerCallbackManager<S, T> extends AbstractManager {
@@ -36,9 +36,9 @@ public class BiConsumerCallbackManager<S, T> extends AbstractManager {
 	private final Map<S, List<BiConsumer<S, T>>> callbacks;
 	
 	public BiConsumerCallbackManager(final ExecutorService executorService, 
-			final BitfinexApiBroker bitfinexApiBroker) {
+			final BitfinexWebsocketClient client) {
 		
-		super(bitfinexApiBroker, executorService);
+		super(client, executorService);
 		this.callbacks = new ConcurrentHashMap<>();
 	}
 	

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/ConnectionFeatureManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/ConnectionFeatureManager.java
@@ -22,8 +22,8 @@ import java.util.concurrent.ExecutorService;
 
 import com.google.common.collect.Sets;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.command.SetConnectionFeaturesCommand;
 
 public class ConnectionFeatureManager extends AbstractManager {
@@ -40,9 +40,9 @@ public class ConnectionFeatureManager extends AbstractManager {
 	private int activeConnectionFeatures;
 	
 	
-	public ConnectionFeatureManager(final BitfinexApiBroker bitfinexApiBroker, 
+	public ConnectionFeatureManager(final BitfinexWebsocketClient client,
 			final ExecutorService executorService) {
-		super(bitfinexApiBroker, executorService);
+		super(client, executorService);
 		
 		this.connectionFeatures = Sets.newConcurrentHashSet();
 		this.activeConnectionFeatures = 0;
@@ -105,6 +105,6 @@ public class ConnectionFeatureManager extends AbstractManager {
 	 */
 	public void applyConnectionFeatures() {
 		final SetConnectionFeaturesCommand apiCommand = new SetConnectionFeaturesCommand(connectionFeatures);
-		bitfinexApiBroker.sendCommand(apiCommand);
+		client.sendCommand(apiCommand);
 	}
 }

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/OrderbookManager.java
@@ -20,7 +20,7 @@ package com.github.jnidzwetzki.bitfinex.v2.manager;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderBookEntry;
@@ -34,10 +34,10 @@ public class OrderbookManager extends AbstractManager {
 	 */
 	private final BiConsumerCallbackManager<BitfinexOrderBookSymbol, BitfinexOrderBookEntry> channelCallbacks;
 
-	public OrderbookManager(final BitfinexApiBroker bitfinexApiBroker, ExecutorService executorService) {
-		super(bitfinexApiBroker, executorService);
-		this.channelCallbacks = new BiConsumerCallbackManager<>(executorService, bitfinexApiBroker);
-        bitfinexApiBroker.getCallbacks().onOrderbookEvent((sym,entries) -> {
+	public OrderbookManager(final BitfinexWebsocketClient client, ExecutorService executorService) {
+		super(client, executorService);
+		this.channelCallbacks = new BiConsumerCallbackManager<>(executorService, client);
+        client.getCallbacks().onOrderbookEvent((sym,entries) -> {
 			entries.forEach(e -> handleNewOrderbookEntry(sym, e));
 		});
 	}
@@ -69,7 +69,7 @@ public class OrderbookManager extends AbstractManager {
 		final SubscribeOrderbookCommand subscribeOrderbookCommand
 			= new SubscribeOrderbookCommand(orderbookConfiguration);
 
-		bitfinexApiBroker.sendCommand(subscribeOrderbookCommand);
+		client.sendCommand(subscribeOrderbookCommand);
 	}
 
 	/**
@@ -77,7 +77,7 @@ public class OrderbookManager extends AbstractManager {
 	 */
 	public void unsubscribeOrderbook(final BitfinexOrderBookSymbol orderbookConfiguration) {
 		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(orderbookConfiguration);
-		bitfinexApiBroker.sendCommand(command);
+		client.sendCommand(command);
 	}
 
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/PositionManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/PositionManager.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexPosition;
 
 public class PositionManager extends SimpleCallbackManager<BitfinexPosition> {
@@ -31,10 +31,10 @@ public class PositionManager extends SimpleCallbackManager<BitfinexPosition> {
 	 */
 	private final List<BitfinexPosition> positions;
 
-	public PositionManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService) {
-		super(executorService, bitfinexApiBroker);
+	public PositionManager(final BitfinexWebsocketClient client, final ExecutorService executorService) {
+		super(executorService, client);
 		this.positions = new ArrayList<>();
-		bitfinexApiBroker.getCallbacks().onPositionsEvent((account, positions) -> positions.forEach(this::updatePosition));
+		client.getCallbacks().onPositionsEvent((account, positions) -> positions.forEach(this::updatePosition));
 	}
 
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/RawOrderbookManager.java
@@ -20,7 +20,7 @@ package com.github.jnidzwetzki.bitfinex.v2.manager;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.UnsubscribeChannelCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexOrderBookEntry;
@@ -34,10 +34,10 @@ public class RawOrderbookManager extends AbstractManager {
 	 */
 	private final BiConsumerCallbackManager<BitfinexOrderBookSymbol, BitfinexOrderBookEntry> channelCallbacks;
 
-	public RawOrderbookManager(final BitfinexApiBroker bitfinexApiBroker, ExecutorService executorService) {
-		super(bitfinexApiBroker, executorService);
-		this.channelCallbacks = new BiConsumerCallbackManager<>(executorService, bitfinexApiBroker);
-		bitfinexApiBroker.getCallbacks().onRawOrderbookEvent((sym, entries) -> {
+	public RawOrderbookManager(final BitfinexWebsocketClient client, ExecutorService executorService) {
+		super(client, executorService);
+		this.channelCallbacks = new BiConsumerCallbackManager<>(executorService, client);
+		client.getCallbacks().onRawOrderbookEvent((sym, entries) -> {
 			entries.forEach(e -> handleNewOrderbookEntry(sym, e));
 		});
 	}
@@ -73,7 +73,7 @@ public class RawOrderbookManager extends AbstractManager {
 	public void subscribeOrderbook(final BitfinexOrderBookSymbol symbol) {
 		
 		final SubscribeOrderbookCommand subscribeOrderbookCommand = new SubscribeOrderbookCommand(symbol);
-		bitfinexApiBroker.sendCommand(subscribeOrderbookCommand);
+		client.sendCommand(subscribeOrderbookCommand);
 	}
 	
 	/**
@@ -82,7 +82,7 @@ public class RawOrderbookManager extends AbstractManager {
 	 */
 	public void unsubscribeOrderbook(final BitfinexOrderBookSymbol symbol) {
 		final UnsubscribeChannelCommand command = new UnsubscribeChannelCommand(symbol);
-		bitfinexApiBroker.sendCommand(command);
+		client.sendCommand(command);
 	}
 	
 	/**

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/SimpleCallbackManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/SimpleCallbackManager.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 
 public class SimpleCallbackManager<T> extends AbstractManager {
 	
@@ -32,8 +32,8 @@ public class SimpleCallbackManager<T> extends AbstractManager {
 	private final List<Consumer<T>> callbacks;
 	
 	public SimpleCallbackManager(final ExecutorService executorService, 
-			final BitfinexApiBroker bitfinexApiBroker) {
-		super(bitfinexApiBroker, executorService);
+			final BitfinexWebsocketClient client) {
+		super(client, executorService);
 		this.callbacks = new ArrayList<>();
 	}
 	

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/TradeManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/TradeManager.java
@@ -19,15 +19,15 @@ package com.github.jnidzwetzki.bitfinex.v2.manager;
 
 import java.util.concurrent.ExecutorService;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexMyExecutedTrade;
 import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexAccountSymbol;
 
 public class TradeManager extends SimpleCallbackManager<BitfinexMyExecutedTrade> {
 
-	public TradeManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService) {
-		super(executorService, bitfinexApiBroker);
-		bitfinexApiBroker.getCallbacks().onTradeEvent(this::updateTrade);
+	public TradeManager(final BitfinexWebsocketClient client, final ExecutorService executorService) {
+		super(executorService, client);
+		client.getCallbacks().onTradeEvent(this::updateTrade);
 	}
 	
 	/**
@@ -35,7 +35,7 @@ public class TradeManager extends SimpleCallbackManager<BitfinexMyExecutedTrade>
 	 * @param trade
 	 */
 	public void updateTrade(final BitfinexAccountSymbol account, final BitfinexMyExecutedTrade trade) {
-		trade.setApiKey(bitfinexApiBroker.getConfiguration().getApiKey());
+		trade.setApiKey(client.getConfiguration().getApiKey());
 		notifyCallbacks(trade);
 	}
 	

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/WalletManager.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/manager/WalletManager.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ExecutorService;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.command.CalculateCommand;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexWallet;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
@@ -36,10 +36,10 @@ public class WalletManager extends AbstractManager {
 	 */
 	private final Table<BitfinexWallet.Type, String, BitfinexWallet> walletTable;
 
-	public WalletManager(final BitfinexApiBroker bitfinexApiBroker, final ExecutorService executorService) {
-		super(bitfinexApiBroker, executorService);
+	public WalletManager(final BitfinexWebsocketClient client, final ExecutorService executorService) {
+		super(client, executorService);
 		this.walletTable = HashBasedTable.create();
-		bitfinexApiBroker.getCallbacks().onWalletsEvent((account, wallets) -> wallets.forEach(wallet -> {
+		client.getCallbacks().onWalletsEvent((account, wallets) -> wallets.forEach(wallet -> {
             try {
                 Table<BitfinexWallet.Type, String, BitfinexWallet> walletTable = getWalletTable();
                 synchronized (walletTable) {
@@ -80,7 +80,7 @@ public class WalletManager extends AbstractManager {
 	 * @throws APIException
 	 */
 	private void throwExceptionIfUnauthenticated() throws APIException {
-		if(! bitfinexApiBroker.isAuthenticated()) {
+		if(! client.isAuthenticated()) {
 			throw new APIException("Unable to perform operation on an unauthenticated connection");
 		}
 	}
@@ -94,7 +94,7 @@ public class WalletManager extends AbstractManager {
 	public void calculateWalletMarginBalance(final String symbol) throws APIException {
 		throwExceptionIfUnauthenticated();
 
-		bitfinexApiBroker.sendCommand(new CalculateCommand("wallet_margin_" + symbol));
+		client.sendCommand(new CalculateCommand("wallet_margin_" + symbol));
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class WalletManager extends AbstractManager {
 	public void calculateWalletFundingBalance(final String symbol) throws APIException {
 		throwExceptionIfUnauthenticated();
 
-		bitfinexApiBroker.sendCommand(new CalculateCommand("wallet_funding_" + symbol));
+		client.sendCommand(new CalculateCommand("wallet_funding_" + symbol));
 	}
 
 }

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/PooledBitfinexApiBrokerIT.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/PooledBitfinexApiBrokerIT.java
@@ -1,0 +1,45 @@
+package com.github.jnidzwetzki.bitfinex.v2;
+
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeCandlesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeOrderbookCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTickerCommand;
+import com.github.jnidzwetzki.bitfinex.v2.command.SubscribeTradesCommand;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
+import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexOrderBookSymbol;
+import com.github.jnidzwetzki.bitfinex.v2.symbol.BitfinexSymbols;
+
+public class PooledBitfinexApiBrokerIT {
+
+    @Test(timeout = 60_000)
+    public void testSubscriptions() throws InterruptedException {
+        // given
+        BitfinexWebsocketConfiguration config = new BitfinexWebsocketConfiguration();
+        PooledBitfinexApiBroker client = (PooledBitfinexApiBroker) BitfinexClientFactory.pooledClient(config, 50);
+
+        int channelLimit = 150;
+        // when
+        CountDownLatch subsLatch = new CountDownLatch(channelLimit * 4);
+        client.getCallbacks().onSubscribeChannelEvent(chan -> subsLatch.countDown());
+
+        client.connect();
+        BitfinexCurrencyPair.values().stream()
+                .limit(channelLimit)
+                .forEach(bfxPair -> {
+                    client.sendCommand(new SubscribeCandlesCommand(BitfinexSymbols.candlesticks(bfxPair, BitfinexCandleTimeFrame.MINUTES_1)));
+                    client.sendCommand(new SubscribeOrderbookCommand(BitfinexSymbols.orderBook(bfxPair, BitfinexOrderBookSymbol.Precision.P0, BitfinexOrderBookSymbol.Frequency.F0, 100)));
+                    client.sendCommand(new SubscribeTickerCommand(BitfinexSymbols.ticker(bfxPair)));
+                    client.sendCommand(new SubscribeTradesCommand(BitfinexSymbols.executedTrades(bfxPair)));
+                });
+        // then
+        subsLatch.await();
+        Assert.assertEquals(channelLimit * 4, client.getSubscribedChannels().size());
+        Assert.assertEquals(3, client.websocketConnCount());
+    }
+
+}

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/BitfinexPositionTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/BitfinexPositionTest.java
@@ -25,8 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.account.info.PositionHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexPosition;
@@ -47,7 +48,7 @@ public class BitfinexPositionTest {
 		final String jsonString = "[0,\"pu\",[\"tETHUSD\",\"ACTIVE\",0.14,713.78,-0.00330012,0,null,null,null,null]]";
 		final JSONArray jsonArray = new JSONArray(jsonString);
 
-		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
+		final BitfinexWebsocketClient bitfinexApiBroker = buildMockedBitfinexConnection();
 		final PositionHandler positionHandler = new PositionHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		positionHandler.onPositionsEvent((a, positions) -> {
 			for (BitfinexPosition position : positions) {
@@ -56,7 +57,7 @@ public class BitfinexPositionTest {
 		});
 
 		Assert.assertTrue(bitfinexApiBroker.getPositionManager().getPositions().isEmpty());
-		positionHandler.handleChannelData(null, jsonArray);
+		positionHandler.handleChannelData("pu", jsonArray.getJSONArray(2));
 		Assert.assertEquals(1, bitfinexApiBroker.getPositionManager().getPositions().size());
 	}
 	
@@ -70,7 +71,7 @@ public class BitfinexPositionTest {
 		final String jsonString = "[0,\"pu\",[\"tETHUSD\",\"ACTIVE\",0.14,713.78,-0.00330012,null,null,null,null,null]]";
 		final JSONArray jsonArray = new JSONArray(jsonString);
 
-		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
+		final BitfinexWebsocketClient bitfinexApiBroker = buildMockedBitfinexConnection();
 		final PositionHandler positionHandler = new PositionHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		positionHandler.onPositionsEvent((a, positions) -> {
 			for (BitfinexPosition position : positions) {
@@ -79,7 +80,7 @@ public class BitfinexPositionTest {
 		});
 
 		Assert.assertTrue(bitfinexApiBroker.getPositionManager().getPositions().isEmpty());
-		positionHandler.handleChannelData(null, jsonArray);
+		positionHandler.handleChannelData("pu", jsonArray.getJSONArray(2));
 		Assert.assertEquals(1, bitfinexApiBroker.getPositionManager().getPositions().size());
 	}
 	
@@ -93,7 +94,7 @@ public class BitfinexPositionTest {
 		final String jsonString = "[0,\"ps\",[[\"tETHUSD\",\"ACTIVE\",0.14,713.78,-0.00330012,0,null,null,null,null], [\"tBTCUSD\",\"ACTIVE\",0.14,713.78,-0.00330012,0,null,null,null,null]]]";
 		final JSONArray jsonArray = new JSONArray(jsonString);
 
-		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
+		final BitfinexWebsocketClient bitfinexApiBroker = buildMockedBitfinexConnection();
 		final PositionHandler positionHandler = new PositionHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
 		positionHandler.onPositionsEvent((a, positions) -> {
 			for (BitfinexPosition position : positions) {
@@ -102,7 +103,7 @@ public class BitfinexPositionTest {
 		});
 
 		Assert.assertTrue(bitfinexApiBroker.getPositionManager().getPositions().isEmpty());
-		positionHandler.handleChannelData(null, jsonArray);
+		positionHandler.handleChannelData("ps", jsonArray.getJSONArray(2));
 		Assert.assertEquals(2, bitfinexApiBroker.getPositionManager().getPositions().size());
 	}
 	
@@ -110,10 +111,10 @@ public class BitfinexPositionTest {
 	 * Build a mocked bitfinex connection
 	 * @return
 	 */
-	private BitfinexApiBroker buildMockedBitfinexConnection() {
+	private BitfinexWebsocketClient buildMockedBitfinexConnection() {
 		
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
 		Mockito.when(bitfinexApiBroker.getCallbacks()).thenReturn(new BitfinexApiCallbackRegistry());
 
 		final PositionManager positionManager = new PositionManager(bitfinexApiBroker, executorService);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/CommandsTest.java
@@ -8,9 +8,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexOrderBuilder;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketConfiguration;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.command.AuthCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.BitfinexCommand;
 import com.github.jnidzwetzki.bitfinex.v2.command.CancelOrderCommand;
@@ -67,7 +68,7 @@ public class CommandsTest {
 				new UnsubscribeChannelCommand(orderbookConfiguration),
 				new SetConnectionFeaturesCommand(new HashSet<>()));
 
-		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
+		final BitfinexWebsocketClient bitfinexApiBroker = buildMockedBitfinexConnection();
 
 		for(final BitfinexCommand command : commands) {
 			if (command instanceof BitfinexStreamSymbolToChannelIdResolverAware) {
@@ -97,7 +98,7 @@ public class CommandsTest {
 
 		final OrderCommand command = new OrderCommand(order);
 
-		final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
+		final BitfinexWebsocketClient bitfinexApiBroker = buildMockedBitfinexConnection();
 
 		final String commandValue = command.getCommand(bitfinexApiBroker);
 		Assert.assertNotNull(commandValue);
@@ -109,9 +110,9 @@ public class CommandsTest {
 	 *  Build the bitfinex connection
 	 * @return
 	 */
-	private BitfinexApiBroker buildMockedBitfinexConnection() {
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-		final BitfinexApiBrokerConfig config = Mockito.mock(BitfinexApiBrokerConfig.class);
+	private BitfinexWebsocketClient buildMockedBitfinexConnection() {
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
+		final BitfinexWebsocketConfiguration config = Mockito.mock(BitfinexWebsocketConfiguration.class);
 
 		Mockito.when(bitfinexApiBroker.getConfiguration()).thenReturn(config);
 		Mockito.when(bitfinexApiBroker.getConfiguration().getApiKey()).thenReturn("abc");

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/HeartbeatManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/HeartbeatManagerTest.java
@@ -26,8 +26,9 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.HeartbeatThread;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.WebsocketClientEndpoint;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.HeartbeatHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
@@ -54,7 +55,7 @@ public class HeartbeatManagerTest {
 				return null;
 		};
 
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
 
 		final WebsocketClientEndpoint websocketClientEndpoint = Mockito.mock(WebsocketClientEndpoint.class);
 		Mockito.when(websocketClientEndpoint.isConnected()).thenReturn(connectLatch.getCount() == 0);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/IntegrationTest.java
@@ -25,11 +25,12 @@ import java.util.function.BiConsumer;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexConnectionFeature;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketConfiguration;
 import com.github.jnidzwetzki.bitfinex.v2.SequenceNumberAuditor;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandle;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
@@ -55,7 +56,7 @@ public class IntegrationTest {
 	@Test
 	public void testWalletsOnUnauthClient() throws APIException {
 
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		try {
 			bitfinexClient.connect();
@@ -85,7 +86,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=30000)
 	public void testOrderbookStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		// Await at least 10 callbacks
 		final CountDownLatch latch = new CountDownLatch(10);
@@ -127,7 +128,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=30000)
 	public void testRawOrderbookStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		// Await at least 20 callbacks
 		final CountDownLatch latch = new CountDownLatch(20);
@@ -168,7 +169,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=30000)
 	public void testCandleStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		try {
 			bitfinexClient.connect();
@@ -211,7 +212,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=60000)
 	public void testExecutedTradesStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		// Await at least 2 callbacks
 		final CountDownLatch latch = new CountDownLatch(2);
@@ -248,7 +249,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=60000)
 	public void testUnsubscrribeAllChannels() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		try {
 			bitfinexClient.connect();
@@ -279,7 +280,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=60000)
 	public void testTickerStream() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		// Await at least 2 callbacks
 		final CountDownLatch latch = new CountDownLatch(2);
@@ -323,9 +324,9 @@ public class IntegrationTest {
 		final String KEY = "key";
 		final String SECRET = "secret";
 
-		BitfinexApiBrokerConfig config = new BitfinexApiBrokerConfig();
+		BitfinexWebsocketConfiguration config = new BitfinexWebsocketConfiguration();
 		config.setApiCredentials(KEY, SECRET);
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(config);
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(config, new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 		Assert.assertEquals(KEY, bitfinexClient.getConfiguration().getApiKey());
 		Assert.assertEquals(SECRET, bitfinexClient.getConfiguration().getApiSecret());
 
@@ -345,7 +346,7 @@ public class IntegrationTest {
 	 */
 	@Test
 	public void testReconnect() throws APIException, InterruptedException {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 		bitfinexClient.connect();
 
 		final BitfinexTickerSymbol symbol = BitfinexSymbols.ticker(BitfinexCurrencyPair.of("BTC","USD"));
@@ -383,7 +384,7 @@ public class IntegrationTest {
 	@Test
 	public void testSequencing() throws APIException, InterruptedException {
 		SequenceNumberAuditor sequenceNumberAuditor = new SequenceNumberAuditor();
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig(), new BitfinexApiCallbackRegistry(), sequenceNumberAuditor);
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), sequenceNumberAuditor);
 		bitfinexClient.connect();
 
 		Assert.assertEquals(-1, sequenceNumberAuditor.getPrivateSequence());
@@ -433,7 +434,7 @@ public class IntegrationTest {
 	 */
 	@Test(timeout=30000)
 	public void testErrorCallback() {
-		final BitfinexApiBroker bitfinexClient = new BitfinexApiBroker(new BitfinexApiBrokerConfig());
+		final BitfinexWebsocketClient bitfinexClient = new SimpleBitfinexApiBroker(new BitfinexWebsocketConfiguration(), new BitfinexApiCallbackRegistry(), new SequenceNumberAuditor());
 
 		// Await at least 5 callbacks
 		final CountDownLatch latch = new CountDownLatch(5);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexExecutedTradesHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexExecutedTradesHandlerTest.java
@@ -25,8 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.ExecutedTradeHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
@@ -57,7 +58,7 @@ public class BitfinexExecutedTradesHandlerTest {
                 = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BTC", "USD"));
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
-        final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+        final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
         Mockito.doReturn(new BitfinexApiCallbackRegistry()).when(bitfinexApiBroker).getCallbacks();
         final QuoteManager quoteManager = new QuoteManager(bitfinexApiBroker, executorService);
         Mockito.when(bitfinexApiBroker.getQuoteManager()).thenReturn(quoteManager);
@@ -90,7 +91,7 @@ public class BitfinexExecutedTradesHandlerTest {
                 = BitfinexSymbols.executedTrades(BitfinexCurrencyPair.of("BTC", "USD"));
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
-        final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+        final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
         Mockito.when(bitfinexApiBroker.getCallbacks()).thenReturn(new BitfinexApiCallbackRegistry());
         final QuoteManager quoteManager = new QuoteManager(bitfinexApiBroker, executorService);
         Mockito.when(bitfinexApiBroker.getQuoteManager()).thenReturn(quoteManager);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexWalletHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/BitfinexWalletHandlerTest.java
@@ -24,7 +24,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.account.info.WalletHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexWallet;
@@ -53,7 +54,7 @@ public class BitfinexWalletHandlerTest {
 		
 		final Table<BitfinexWallet.Type, String, BitfinexWallet> walletTable = HashBasedTable.create();
 
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
 		final WalletManager walletManager = Mockito.mock(WalletManager.class);
 		Mockito.when(bitfinexApiBroker.getWalletManager()).thenReturn(walletManager);
 
@@ -72,7 +73,7 @@ public class BitfinexWalletHandlerTest {
 				}
 			}
 		});
-		walletHandler.handleChannelData(null, jsonArray);
+		walletHandler.handleChannelData("ws", jsonArray.getJSONArray(2));
 
 		Assert.assertEquals(1, walletTable.size());
 		Assert.assertEquals(9, walletTable.get(BitfinexWallet.Type.EXCHANGE, "ETH").getBalance().doubleValue(), DELTA);
@@ -93,7 +94,7 @@ public class BitfinexWalletHandlerTest {
 		
 		final Table<BitfinexWallet.Type, String, BitfinexWallet> walletTable = HashBasedTable.create();
 
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
 		final WalletManager walletManager = Mockito.mock(WalletManager.class);
 		Mockito.when(bitfinexApiBroker.getWalletManager()).thenReturn(walletManager);
 
@@ -112,7 +113,7 @@ public class BitfinexWalletHandlerTest {
 				}
 			}
 		});
-		walletHandler.handleChannelData(null, jsonArray);
+		walletHandler.handleChannelData("ws", jsonArray.getJSONArray(2));
 
 		Assert.assertEquals(9, walletTable.size());
 		

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/CandlestickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/CandlestickHandlerTest.java
@@ -26,8 +26,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.CandlestickHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCandleTimeFrame;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
@@ -58,7 +59,7 @@ public class CandlestickHandlerTest {
 			= BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1);
 
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
 		Mockito.when(bitfinexApiBroker.getCallbacks()).thenReturn(new BitfinexApiCallbackRegistry());
 
 		final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService);
@@ -98,7 +99,7 @@ public class CandlestickHandlerTest {
 			= BitfinexSymbols.candlesticks(BitfinexCurrencyPair.of("BTC","USD"), BitfinexCandleTimeFrame.MINUTES_1);
 
 		final ExecutorService executorService = Executors.newFixedThreadPool(10);
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
 		Mockito.when(bitfinexApiBroker.getCallbacks()).thenReturn(new BitfinexApiCallbackRegistry());
 
 		final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/TickHandlerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/handler/TickHandlerTest.java
@@ -25,8 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.TickHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
 import com.github.jnidzwetzki.bitfinex.v2.exception.APIException;
@@ -57,7 +58,7 @@ public class TickHandlerTest {
         final BitfinexTickerSymbol symbol = BitfinexSymbols.ticker(currencyPair);
 
         final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
-        final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
+        final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
         Mockito.when(bitfinexApiBroker.getCallbacks()).thenReturn(new BitfinexApiCallbackRegistry());
 
         final QuoteManager tickerManager = new QuoteManager(bitfinexApiBroker, executorService);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TestHelper.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TestHelper.java
@@ -22,9 +22,10 @@ import java.util.concurrent.ExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketConfiguration;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.manager.OrderManager;
 import com.github.jnidzwetzki.bitfinex.v2.manager.TradeManager;
@@ -40,11 +41,11 @@ public class TestHelper {
 	 * Build a mocked bitfinex connection
 	 * @return
 	 */
-	public static BitfinexApiBroker buildMockedBitfinexConnection() {
+	public static BitfinexWebsocketClient buildMockedBitfinexConnection() {
 
 		final ExecutorService executorService = MoreExecutors.newDirectExecutorService();
-		final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-		final BitfinexApiBrokerConfig config = Mockito.mock(BitfinexApiBrokerConfig.class);
+		final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
+		final BitfinexWebsocketConfiguration config = Mockito.mock(BitfinexWebsocketConfiguration.class);
 
 		Mockito.when(bitfinexApiBroker.getConfiguration()).thenReturn(config);
 		Mockito.when(config.getApiKey()).thenReturn(API_KEY);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TradeManagerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/manager/TradeManagerTest.java
@@ -25,9 +25,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBroker;
-import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiBrokerConfig;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexApiCallbackRegistry;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
+import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketConfiguration;
+import com.github.jnidzwetzki.bitfinex.v2.SimpleBitfinexApiBroker;
 import com.github.jnidzwetzki.bitfinex.v2.callback.channel.account.info.MyExecutedTradeHandler;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexApiKeyPermissions;
 import com.github.jnidzwetzki.bitfinex.v2.entity.BitfinexCurrencyPair;
@@ -59,7 +60,7 @@ public class TradeManagerTest {
     public void testTradeChannelHandler1() throws APIException, InterruptedException {
         final String jsonString = "[0,\"te\",[106655593,\"tBTCUSD\",1512247319827,5691690918,-0.002,10894,null,null,-1]]";
         final JSONArray jsonArray = new JSONArray(jsonString);
-        final BitfinexApiBroker bitfinexApiBroker = buildMockedBitfinexConnection();
+        final BitfinexWebsocketClient bitfinexApiBroker = buildMockedBitfinexConnection();
         final MyExecutedTradeHandler tradeHandler = new MyExecutedTradeHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         tradeHandler.onTradeEvent((a, trade) -> bitfinexApiBroker.getTradeManager().updateTrade(a, trade));
 
@@ -75,7 +76,7 @@ public class TradeManagerTest {
             Assert.assertTrue(t.toString().length() > 0);
         });
 
-        tradeHandler.handleChannelData("te", jsonArray);
+        tradeHandler.handleChannelData("te", jsonArray.getJSONArray(2));
     }
 
     /**
@@ -89,7 +90,7 @@ public class TradeManagerTest {
         final String jsonString = "[0,\"te\",[106655593,\"tBTCUSD\",1512247319827,5691690918,-0.002,10894,\"EXCHANGE MARKET\",10894,-1,-0.0392184,\"USD\"]]";
 
         final JSONArray jsonArray = new JSONArray(jsonString);
-        final BitfinexApiBroker bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
+        final BitfinexWebsocketClient bitfinexApiBroker = TestHelper.buildMockedBitfinexConnection();
         final MyExecutedTradeHandler tradeHandler = new MyExecutedTradeHandler(0, BitfinexSymbols.account("api-key", BitfinexApiKeyPermissions.ALL_PERMISSIONS));
         tradeHandler.onTradeEvent((a, trade) -> bitfinexApiBroker.getTradeManager().updateTrade(a, trade));
 
@@ -109,7 +110,7 @@ public class TradeManagerTest {
             Assert.assertTrue(t.toString().length() > 0);
         });
 
-        tradeHandler.handleChannelData("te", jsonArray);
+        tradeHandler.handleChannelData("te", jsonArray.getJSONArray(2));
     }
 
     /**
@@ -117,11 +118,11 @@ public class TradeManagerTest {
      *
      * @return
      */
-    private BitfinexApiBroker buildMockedBitfinexConnection() {
+    private BitfinexWebsocketClient buildMockedBitfinexConnection() {
 
         final ExecutorService executorService = Executors.newFixedThreadPool(10);
-        final BitfinexApiBroker bitfinexApiBroker = Mockito.mock(BitfinexApiBroker.class);
-        final BitfinexApiBrokerConfig config = Mockito.mock(BitfinexApiBrokerConfig.class);
+        final BitfinexWebsocketClient bitfinexApiBroker = Mockito.mock(SimpleBitfinexApiBroker.class);
+        final BitfinexWebsocketConfiguration config = Mockito.mock(BitfinexWebsocketConfiguration.class);
 
         Mockito.when(bitfinexApiBroker.getConfiguration()).thenReturn(config);
         Mockito.when(config.getApiKey()).thenReturn(API_KEY);

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -17,28 +17,16 @@
        
  -->
 
-<Configuration status="warn" name="crypto-bot" packages="">
+<Configuration status="warn" name="bitfinex-v2-wss-api" packages="">
     <Appenders>
-        <RollingFile name="cryptobot_RollingFile" fileName="/tmp/crypto-bot.log"
-                     filePattern="crypto-bot.%d{MM-dd-yyyy}-%i.log.gz">
-            <PatternLayout>
-                <Pattern>%-4r [%t] %d %-5p %c{1} %M() - %m%n</Pattern>
-            </PatternLayout>
-            <Policies>
-                <TimeBasedTriggeringPolicy/>
-                <SizeBasedTriggeringPolicy size="100 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="90"/>
-        </RollingFile>
         <Console name="STDOUT" target="SYSTEM_OUT">
             <PatternLayout>
-                <Pattern>%-4r [%t] %d %-5p %c{1} %M() - %m%n</Pattern>
+                <Pattern>%d{HH:mm:ss.SSS} [%threadId] %-5p %c{1.} - %m%n</Pattern>
             </PatternLayout>
         </Console>
     </Appenders>
     <Loggers>
         <Root level="debug">
-            <AppenderRef ref="cryptobot_RollingFile" level="debug"/>
             <AppenderRef ref="STDOUT" level="debug"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
Hi Jan,
BitfinexCurrencyPair: illegal symbol
One of the pairs was not existing

log4j2: logging pattern for tests updated
I've saved up some more space for actual message of the log

PooledBitfinexApiBroker: implementation
I've implemented a client supporting channels split across multiple websocket connections as per docs (https://docs.bitfinex.com/v2/docs/ws-general#section-subscribe-to-channels).

If all is fine with this PR - I will review the code base as a whole tmrw, and eventually update bits, then update documentation.

-- miron