### PR TITLE
AccountInfoHandler: not handled "hb" on channel 0 even if not authenticated - fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Version 0.7.1 (TBA)
 * New Feature: The available currencies are now fetched directly from Bitfinex
 * New Feature: Added WSv2 order flag support (see https://docs.bitfinex.com/v2/docs/changelog)
+* Bugfix: Missing account-info-handler ("0"-channel) for "hb" event only when user not authenticated
 
 # Version 0.7.0 (17.09.2018)
 * New Feature: PooledBitfinexApiBroker - as per requirement described in https://www.bitfinex.com/posts/267

--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/SimpleBitfinexApiBroker.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/SimpleBitfinexApiBroker.java
@@ -236,6 +236,10 @@ public class SimpleBitfinexApiBroker implements Closeable, BitfinexWebsocketClie
 		commandCallbacks.put("unsubscribed", unsubscribed);
 
 		final AuthCallback auth = new AuthCallback();
+		AccountInfoHandler accountInfoHandler = new AccountInfoHandler(0, BitfinexSymbols.account(null, BitfinexApiKeyPermissions.NO_PERMISSIONS));
+		accountInfoHandler.onHeartbeatEvent(timestamp -> this.updateConnectionHeartbeat());
+		channelIdToHandlerMap.put(0, accountInfoHandler);
+
 		auth.onAuthenticationSuccessEvent(permissions -> {
 		    logger.info("authentication succeeded for key {}", configuration.getApiKey());
 			final BitfinexAccountSymbol symbol = BitfinexSymbols.account(configuration.getApiKey(), permissions);

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/integration/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/integration/IntegrationTest.java
@@ -276,7 +276,7 @@ public class IntegrationTest {
 			subscribe1.waitForCompletion();
 			subscribe2.waitForCompletion();
 
-			Assert.assertEquals(2, bitfinexClient.getSubscribedChannels().size());
+			Assert.assertEquals(3, bitfinexClient.getSubscribedChannels().size());
 			bitfinexClient.unsubscribeAllChannels();
 			Assert.assertTrue(bitfinexClient.getSubscribedChannels().isEmpty());
 		} catch (Exception e) {

--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/integration/PooledBitfinexApiBrokerTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/integration/PooledBitfinexApiBrokerTest.java
@@ -61,8 +61,10 @@ public class PooledBitfinexApiBrokerTest {
        
         // then
         subsLatch.await();
-        Assert.assertEquals(channelLimit * 3, client.getSubscribedChannels().size());
-        Assert.assertEquals(channelLimit * 3 / channelsPerConnection, client.websocketConnCount());
+
+        final int channelsSubscribed = channelLimit * 3 + client.websocketConnCount();
+        Assert.assertEquals(channelsSubscribed, client.getSubscribedChannels().size());
+        Assert.assertEquals(channelsSubscribed / channelsPerConnection, client.websocketConnCount() - 1);
         
         client.close();
     }


### PR DESCRIPTION
Hi Jan,
Apparently bitfinex exchange was sending "hb" event on 0 channel, even if user is not authenticated. That was causing issues, especially in PooledBitfinexApiBroker.

Here's a fix for that case.
We will need to release new version to maven central sadly 👎 sorry about that.

--- Miron