### PR TITLE
SimpleBitfinexApiBroker: unsubscribeAllChannels fixed

### DIFF
--- a/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/integration/IntegrationTest.java
+++ b/src/test/java/com/github/jnidzwetzki/bitfinex/v2/test/integration/IntegrationTest.java
@@ -276,7 +276,7 @@ public class IntegrationTest {
 			subscribe1.waitForCompletion();
 			subscribe2.waitForCompletion();
 
-			Assert.assertEquals(3, bitfinexClient.getSubscribedChannels().size());
+			Assert.assertEquals(2, bitfinexClient.getSubscribedChannels().size());
 			bitfinexClient.unsubscribeAllChannels();
 			Assert.assertTrue(bitfinexClient.getSubscribedChannels().isEmpty());
 		} catch (Exception e) {


### PR DESCRIPTION
Hi Jan,
I've fixed SimpleBitfinexApiBroker#unsubscribeAllChannels

SimpleBitfinexApiBroker#getSubscribedChannels() omits BitfinexAccountSymbol from this commit on as it's always active - and it's not user-subcribed channel

-- Miron