### PR TITLE
Fix OrderCancelGroupCommand gid parameter

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/OrderCancelGroupCommand.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/command/OrderCancelGroupCommand.java
@@ -22,6 +22,8 @@ import org.json.JSONObject;
 import com.github.jnidzwetzki.bitfinex.v2.BitfinexWebsocketClient;
 import com.github.jnidzwetzki.bitfinex.v2.exception.BitfinexCommandException;
 
+import java.util.Collections;
+
 public class OrderCancelGroupCommand implements BitfinexOrderCommand {
 
 	/**
@@ -36,7 +38,7 @@ public class OrderCancelGroupCommand implements BitfinexOrderCommand {
 	@Override
 	public String getCommand(BitfinexWebsocketClient client) throws BitfinexCommandException {
 		final JSONObject cancelJson = new JSONObject();
-		cancelJson.put("gid", orderGroup);
+		cancelJson.put("gid",  Collections.singletonList(orderGroup));
 		return "[0, \"oc_multi\", null, " + cancelJson.toString() + "]";
 	}
 


### PR DESCRIPTION
https://docs.bitfinex.com/reference#ws-auth-input-order-cancel-multi
```
// Cancel multiple orders using Group ID
[
  0,
  "oc_multi",
  null,
  {
     "gid": [GID, 11, ...]
  }
]
```
Old version didn't work for me but with this change it works just fine