### PR TITLE
Fix violations of Sonar rule 2111

### DIFF
--- a/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexCandle.java
+++ b/src/main/java/com/github/jnidzwetzki/bitfinex/v2/entity/BitfinexCandle.java
@@ -83,8 +83,7 @@ public class BitfinexCandle implements Comparable<BitfinexCandle>{
 	public BitfinexCandle(final long timestamp, final double open, final double close, 
 			final double high, final double low, final double volume) {
 		
-		this(timestamp, new BigDecimal(open), new BigDecimal(close),  new BigDecimal(high), 
-				new BigDecimal(low), Optional.of(new BigDecimal(volume)));
+		this(timestamp, BigDecimal.valueOf(open), BigDecimal.valueOf(close), BigDecimal.valueOf(high), BigDecimal.valueOf(low), Optional.of(BigDecimal.valueOf(volume)));
 	}
 	
 	public long getTimestamp() {


### PR DESCRIPTION
Hi @jnidzwetzki ,

This PR fixes 1 violations of Sonar Rule 2111: '"BigDecimal(double)" should not be used'. This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool Sorald. For details on the fix applied here, please see Sorald's documentation on rule 2111.

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.